### PR TITLE
feature:Refactor pie sankey xychart renderer to vchart

### DIFF
--- a/.cspell/code-terms.txt
+++ b/.cspell/code-terms.txt
@@ -145,6 +145,7 @@ vchart
 verifymethod
 VERIFYMTHD
 visactor
+vtable
 WARN_DOCSDIR_DOESNT_MATCH
 xhost
 yaxis

--- a/.cspell/code-terms.txt
+++ b/.cspell/code-terms.txt
@@ -141,8 +141,10 @@ typeof
 typestr
 unshift
 urlsafe
+vchart
 verifymethod
 VERIFYMTHD
+visactor
 WARN_DOCSDIR_DOESNT_MATCH
 xhost
 yaxis

--- a/.cspell/libraries.txt
+++ b/.cspell/libraries.txt
@@ -75,6 +75,8 @@ Typora
 unocss
 unplugin
 unstub
+vchart
+visactor
 vite
 vitest
 Zune

--- a/.cspell/libraries.txt
+++ b/.cspell/libraries.txt
@@ -79,4 +79,5 @@ vchart
 visactor
 vite
 vitest
+vtable
 Zune

--- a/demos/gantt.html
+++ b/demos/gantt.html
@@ -212,6 +212,69 @@
     </pre>
     <hr />
 
+    <!-- VChart渲染器测试 -->
+    <h2>VChart渲染器测试</h2>
+    <p>以下示例使用VChart渲染器进行渲染</p>
+
+    <pre class="mermaid">
+    %%{init: {"gantt": {"renderer": "vchart"}}}%%
+    gantt
+      title VChart甘特图测试 - 基础功能
+      dateFormat YYYY-MM-DD
+      section 开发阶段
+      需求分析    :done, req, 2024-01-01, 2024-01-05
+      系统设计    :active, design, 2024-01-03, 2024-01-10
+      编码实现    :crit, coding, after design, 10d
+      测试验收    :milestone, testing, 2024-01-20, 0d
+      section 部署阶段
+      环境准备    :env, 2024-01-18, 3d
+      系统部署    :deploy, after env, 2d
+      上线运行    :online, after deploy, 1d
+    </pre>
+    <hr />
+
+    <pre class="mermaid">
+    %%{init: {"gantt": {"renderer": "vchart"}}}%%
+    gantt
+      title VChart甘特图测试 - 复杂项目
+      dateFormat YYYY-MM-DD
+      axisFormat %m-%d
+      section 前端开发
+      组件设计     :done, fe1, 2024-01-01, 5d
+      页面开发     :active, fe2, after fe1, 8d
+      界面测试     :fe3, after fe2, 3d
+      section 后端开发
+      API设计      :done, be1, 2024-01-02, 4d
+      数据库设计   :done, be2, 2024-01-03, 3d
+      接口开发     :crit, be3, after be1, 10d
+      性能优化     :be4, after be3, 5d
+      section 测试阶段
+      单元测试     :test1, after fe2, 3d
+      集成测试     :crit, test2, after be3, 4d
+      用户测试     :test3, after test2, 3d
+      section 发布
+      预发布       :milestone, pre, after test3, 0d
+      正式发布     :milestone, release, after pre, 0d
+    </pre>
+    <hr />
+
+    <pre class="mermaid">
+    %%{init: {"gantt": {"renderer": "vchart"}}}%%
+    gantt
+      title VChart甘特图测试 - 紧凑模式
+      dateFormat HH:mm:ss
+      axisFormat %H:%M
+      section 数据处理
+      数据采集: 09:00:00, 30m
+      数据清洗: 09:30:00, 45m
+      数据分析: 10:15:00, 60m
+      section 报告生成
+      图表制作: 11:15:00, 40m
+      报告编写: 11:55:00, 35m
+      报告审核: 12:30:00, 25m
+    </pre>
+    <hr />
+
     <script>
       function ganttTestClick(a, b, c) {
         console.log('a:', a);
@@ -233,7 +296,10 @@
       mermaid.initialize({
         logLevel: 3,
         securityLevel: 'loose',
-        gantt: { axisFormat: '%m/%d/%Y' },
+        gantt: {
+          axisFormat: '%m/%d/%Y',
+          renderer: 'vchart',
+        },
       });
     </script>
   </body>

--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -72,6 +72,8 @@
     "@mermaid-js/parser": "workspace:^",
     "@types/d3": "^7.4.3",
     "@visactor/vchart": "^2.0.2",
+    "@visactor/vtable": "^1.19.9",
+    "@visactor/vtable-gantt": "^1.19.9",
     "cytoscape": "^3.29.3",
     "cytoscape-cose-bilkent": "^4.1.0",
     "cytoscape-fcose": "^2.2.0",

--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -71,6 +71,7 @@
     "@iconify/utils": "^2.1.33",
     "@mermaid-js/parser": "workspace:^",
     "@types/d3": "^7.4.3",
+    "@visactor/vchart": "^2.0.2",
     "cytoscape": "^3.29.3",
     "cytoscape-cose-bilkent": "^4.1.0",
     "cytoscape-fcose": "^2.2.0",

--- a/packages/mermaid/src/config.type.ts
+++ b/packages/mermaid/src/config.type.ts
@@ -845,6 +845,13 @@ export interface ErDiagramConfig extends BaseDiagramConfig {
  */
 export interface PieDiagramConfig extends BaseDiagramConfig {
   /**
+   * Decides which rendering engine to use for pie chart rendering.
+   * - default: Use the original D3-based pie chart renderer
+   * - vchart: Use VChart for enhanced rendering capabilities
+   *
+   */
+  renderer?: 'default' | 'vchart';
+  /**
    * Axial position of slice's label from zero at the center to 1 at the outside edges.
    *
    */
@@ -935,6 +942,13 @@ export interface QuadrantChartConfig extends BaseDiagramConfig {
  * via the `definition` "XYChartConfig".
  */
 export interface XYChartConfig extends BaseDiagramConfig {
+  /**
+   * Decides which rendering engine to use for XY chart rendering.
+   * - default: Use the original custom XY chart renderer
+   * - vchart: Use VChart for enhanced rendering capabilities
+   *
+   */
+  renderer?: 'default' | 'vchart';
   /**
    * width of the chart
    */
@@ -1493,6 +1507,13 @@ export interface C4DiagramConfig extends BaseDiagramConfig {
  * via the `definition` "SankeyDiagramConfig".
  */
 export interface SankeyDiagramConfig extends BaseDiagramConfig {
+  /**
+   * Decides which rendering engine to use for sankey diagram rendering.
+   * - default: Use the original D3-sankey based renderer
+   * - vchart: Use VChart for enhanced rendering capabilities
+   *
+   */
+  renderer?: 'default' | 'vchart';
   width?: number;
   height?: number;
   /**

--- a/packages/mermaid/src/diagrams/gantt/ganttRenderer.js
+++ b/packages/mermaid/src/diagrams/gantt/ganttRenderer.js
@@ -374,7 +374,7 @@ export const draw = function (text, id, version, diagObj) {
       .attr('font-size', conf.fontSize)
       .attr('x', function (d) {
         let startX = timeScale(d.startTime);
-        let endX = timeScale(d.renderEndTime || d.endTime);
+        let endX = timeScale(d.renderEndTime ?? d.endTime);
         if (d.milestone) {
           startX += 0.5 * (timeScale(d.endTime) - timeScale(d.startTime)) - 0.5 * theBarHeight;
         }
@@ -791,7 +791,30 @@ export const draw = function (text, id, version, diagObj) {
   }
 };
 
+// 导入VChart渲染器
+import { drawWithVChart } from './ganttVChartRenderer.js';
+
+// 条件渲染器
+const conditionalDraw = async (text, id, _version, diagObj) => {
+  const db = diagObj.db;
+  const config = db.getConfig();
+
+  // 检查是否使用VChart渲染器
+  if (config.renderer === 'vchart') {
+    try {
+      // 检查VChart是否可用
+      await import('@visactor/vchart');
+      return await drawWithVChart(text, id, _version, diagObj);
+    } catch (error) {
+      log.warn('VChart not available, falling back to default renderer:', error);
+    }
+  }
+
+  // 使用默认D3渲染器
+  return draw(text, id, _version, diagObj);
+};
+
 export default {
   setConf,
-  draw,
+  draw: conditionalDraw,
 };

--- a/packages/mermaid/src/diagrams/gantt/ganttRenderer.js
+++ b/packages/mermaid/src/diagrams/gantt/ganttRenderer.js
@@ -791,8 +791,8 @@ export const draw = function (text, id, version, diagObj) {
   }
 };
 
-// 导入VChart渲染器
-import { drawWithVChart } from './ganttVChartRenderer.js';
+// 导入VTable渲染器
+import { drawWithVTable } from './ganttVChartRenderer.js';
 
 // 条件渲染器
 const conditionalDraw = async (text, id, _version, diagObj) => {
@@ -803,8 +803,8 @@ const conditionalDraw = async (text, id, _version, diagObj) => {
   if (config.renderer === 'vchart') {
     try {
       // 检查VChart是否可用
-      await import('@visactor/vchart');
-      return await drawWithVChart(text, id, _version, diagObj);
+      await import('@visactor/vtable-gantt');
+      return await drawWithVTable(text, id, _version, diagObj);
     } catch (error) {
       log.warn('VChart not available, falling back to default renderer:', error);
     }

--- a/packages/mermaid/src/diagrams/gantt/ganttVChart.spec.ts
+++ b/packages/mermaid/src/diagrams/gantt/ganttVChart.spec.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { drawWithVChart } from './ganttVChartRenderer.js';
+
+// Mock VChart
+const mockVChart = {
+  renderAsync: vi.fn().mockResolvedValue(undefined),
+  release: vi.fn(),
+};
+
+vi.mock('@visactor/vchart', () => ({
+  VChart: vi.fn().mockImplementation(() => mockVChart),
+}));
+
+// Mock selectSvgElement
+vi.mock('../../rendering-util/selectSvgElement.js', () => ({
+  selectSvgElement: vi.fn().mockReturnValue({
+    append: vi.fn().mockReturnValue({
+      attr: vi.fn().mockReturnThis(),
+      style: vi.fn().mockReturnThis(),
+      node: vi.fn().mockReturnValue(document.createElement('div')),
+    }),
+  }),
+}));
+
+// Mock configureSvgSize
+vi.mock('../../setupGraphViewbox.js', () => ({
+  configureSvgSize: vi.fn(),
+}));
+
+// Mock cleanAndMerge
+vi.mock('../../utils.js', () => ({
+  cleanAndMerge: vi.fn().mockImplementation((a, b) => ({ ...a, ...b })),
+}));
+
+// Mock getConfig
+vi.mock('../../diagram-api/diagramAPI.js', () => ({
+  getConfig: vi.fn().mockReturnValue({
+    gantt: {
+      useWidth: 1200,
+      renderer: 'vchart',
+    },
+  }),
+}));
+
+describe('Gantt VChart Renderer', () => {
+  const mockDb = {
+    getTasks: vi.fn().mockReturnValue([
+      {
+        id: 'task1',
+        task: '任务1',
+        section: '阶段A',
+        startTime: new Date('2024-01-01'),
+        endTime: new Date('2024-01-05'),
+        renderEndTime: null,
+        active: false,
+        done: true,
+        crit: false,
+        milestone: false,
+        classes: [],
+        order: 0,
+      },
+      {
+        id: 'task2',
+        task: '任务2',
+        section: '阶段A',
+        startTime: new Date('2024-01-03'),
+        endTime: new Date('2024-01-08'),
+        renderEndTime: null,
+        active: true,
+        done: false,
+        crit: true,
+        milestone: false,
+        classes: ['custom-class'],
+        order: 1,
+      },
+      {
+        id: 'milestone1',
+        task: '里程碑1',
+        section: '阶段B',
+        startTime: new Date('2024-01-08'),
+        endTime: new Date('2024-01-08'),
+        renderEndTime: null,
+        active: false,
+        done: false,
+        crit: false,
+        milestone: true,
+        classes: [],
+        order: 2,
+      },
+    ]),
+    getSections: vi.fn().mockReturnValue(['阶段A', '阶段B']),
+    getDiagramTitle: vi.fn().mockReturnValue('项目甘特图'),
+    getDateFormat: vi.fn().mockReturnValue('YYYY-MM-DD'),
+    getAxisFormat: vi.fn().mockReturnValue('%Y-%m-%d'),
+    getTickInterval: vi.fn().mockReturnValue('1day'),
+    getConfig: vi.fn().mockReturnValue({
+      useWidth: 1200,
+      renderer: 'vchart',
+    }),
+  };
+
+  const mockDiagObj = {
+    type: 'gantt',
+    text: 'gantt',
+    parser: {} as any,
+    renderer: {} as any,
+    styles: {} as any,
+    init: vi.fn(),
+    getParser: vi.fn(),
+    getType: vi.fn().mockReturnValue('gantt'),
+    db: mockDb,
+    globalConfig: {
+      gantt: {
+        useWidth: 1200,
+      },
+      themeVariables: {
+        fontFamily: 'Arial, sans-serif',
+        doneTaskBkgColor: '#4CAF50',
+        activeTaskBkgColor: '#2196F3',
+        critBkgColor: '#F44336',
+        taskBkgColor: '#9E9E9E',
+        gridColor: '#e8e8e8',
+        background: '#ffffff',
+      },
+    },
+  } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('应该成功渲染甘特图', async () => {
+    const text = `
+gantt
+    title 项目甘特图
+    dateFormat  YYYY-MM-DD
+    section 阶段A
+    任务1    :done, task1, 2024-01-01, 2024-01-05
+    任务2    :active, crit, task2, 2024-01-03, 2024-01-08
+    section 阶段B
+    里程碑1  :milestone, milestone1, 2024-01-08, 0d
+    `;
+
+    await expect(drawWithVChart(text, 'gantt-test', '1.0.0', mockDiagObj)).resolves.not.toThrow();
+
+    expect(mockVChart.renderAsync).toHaveBeenCalled();
+  });
+
+  it('应该正确提取甘特图数据', async () => {
+    const text = 'gantt\n    title 测试甘特图';
+
+    await drawWithVChart(text, 'gantt-test', '1.0.0', mockDiagObj);
+
+    expect(mockDb.getTasks).toHaveBeenCalled();
+    expect(mockDb.getSections).toHaveBeenCalled();
+    expect(mockDb.getDiagramTitle).toHaveBeenCalled();
+  });
+
+  it('应该处理空数据情况', async () => {
+    const emptyDb = {
+      ...mockDb,
+      getTasks: vi.fn().mockReturnValue([]),
+      getSections: vi.fn().mockReturnValue([]),
+      getDiagramTitle: vi.fn().mockReturnValue(''),
+    };
+
+    const emptyDiagObj = {
+      ...mockDiagObj,
+      db: emptyDb,
+    };
+
+    await expect(
+      drawWithVChart('gantt', 'gantt-empty', '1.0.0', emptyDiagObj)
+    ).resolves.not.toThrow();
+  });
+
+  it('应该正确应用主题变量', async () => {
+    const text = 'gantt\n    title 主题测试';
+
+    await drawWithVChart(text, 'gantt-theme', '1.0.0', mockDiagObj);
+
+    // VChart应该被调用并传入正确的规格
+    expect(mockVChart.renderAsync).toHaveBeenCalled();
+  });
+
+  it('应该处理不同类型的任务', async () => {
+    const mixedTasksDb = {
+      ...mockDb,
+      getTasks: vi.fn().mockReturnValue([
+        {
+          id: 'normal-task',
+          task: '普通任务',
+          section: '测试',
+          startTime: new Date('2024-01-01'),
+          endTime: new Date('2024-01-03'),
+          renderEndTime: null,
+          active: false,
+          done: false,
+          crit: false,
+          milestone: false,
+          classes: [],
+          order: 0,
+        },
+        {
+          id: 'active-task',
+          task: '进行中任务',
+          section: '测试',
+          startTime: new Date('2024-01-02'),
+          endTime: new Date('2024-01-04'),
+          renderEndTime: null,
+          active: true,
+          done: false,
+          crit: false,
+          milestone: false,
+          classes: [],
+          order: 1,
+        },
+        {
+          id: 'done-task',
+          task: '已完成任务',
+          section: '测试',
+          startTime: new Date('2024-01-01'),
+          endTime: new Date('2024-01-02'),
+          renderEndTime: null,
+          active: false,
+          done: true,
+          crit: false,
+          milestone: false,
+          classes: [],
+          order: 2,
+        },
+        {
+          id: 'critical-task',
+          task: '关键任务',
+          section: '测试',
+          startTime: new Date('2024-01-03'),
+          endTime: new Date('2024-01-05'),
+          renderEndTime: null,
+          active: false,
+          done: false,
+          crit: true,
+          milestone: false,
+          classes: [],
+          order: 3,
+        },
+        {
+          id: 'milestone-task',
+          task: '里程碑',
+          section: '测试',
+          startTime: new Date('2024-01-05'),
+          endTime: new Date('2024-01-05'),
+          renderEndTime: null,
+          active: false,
+          done: false,
+          crit: false,
+          milestone: true,
+          classes: [],
+          order: 4,
+        },
+      ]),
+    };
+
+    const mixedDiagObj = {
+      ...mockDiagObj,
+      db: mixedTasksDb,
+    };
+
+    await expect(
+      drawWithVChart('gantt', 'gantt-mixed', '1.0.0', mixedDiagObj)
+    ).resolves.not.toThrow();
+
+    expect(mockVChart.renderAsync).toHaveBeenCalled();
+  });
+
+  it('应该正确处理时间间隔配置', async () => {
+    const intervalDb = {
+      ...mockDb,
+      getTickInterval: vi.fn().mockReturnValue('1week'),
+    };
+
+    const intervalDiagObj = {
+      ...mockDiagObj,
+      db: intervalDb,
+    };
+
+    await expect(
+      drawWithVChart('gantt', 'gantt-interval', '1.0.0', intervalDiagObj)
+    ).resolves.not.toThrow();
+
+    expect(intervalDb.getTickInterval).toHaveBeenCalled();
+  });
+
+  it('应该处理渲染器配置错误', async () => {
+    const errorDb = {
+      ...mockDb,
+      getConfig: vi.fn().mockReturnValue(null),
+    };
+
+    const errorDiagObj = {
+      ...mockDiagObj,
+      db: errorDb,
+    };
+
+    await expect(
+      drawWithVChart('gantt', 'gantt-error', '1.0.0', errorDiagObj)
+    ).resolves.not.toThrow();
+  });
+
+  it('应该清理VChart资源', async () => {
+    const text = 'gantt\n    title 资源清理测试';
+
+    await drawWithVChart(text, 'gantt-cleanup', '1.0.0', mockDiagObj);
+
+    // 渲染器应该调用dispose方法来清理资源
+    // 这里我们验证VChart实例已经被创建
+    expect(mockVChart.renderAsync).toHaveBeenCalled();
+  });
+
+  it('应该支持自定义尺寸', async () => {
+    const customDb = {
+      ...mockDb,
+      getConfig: vi.fn().mockReturnValue({
+        useWidth: 800,
+        renderer: 'vchart',
+      }),
+    };
+
+    const customDiagObj = {
+      ...mockDiagObj,
+      db: customDb,
+    };
+
+    await expect(
+      drawWithVChart('gantt', 'gantt-custom-size', '1.0.0', customDiagObj)
+    ).resolves.not.toThrow();
+
+    expect(mockVChart.renderAsync).toHaveBeenCalled();
+  });
+});

--- a/packages/mermaid/src/diagrams/gantt/ganttVChart.spec.ts
+++ b/packages/mermaid/src/diagrams/gantt/ganttVChart.spec.ts
@@ -1,23 +1,22 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { drawWithVChart } from './ganttVChartRenderer.js';
+import { drawWithVTable } from './ganttVChartRenderer.js';
 
-// Mock VChart
-const mockVChart = {
-  renderAsync: vi.fn().mockResolvedValue(undefined),
+// Mock VTable Gantt
+const mockGantt = {
+  render: vi.fn(),
   release: vi.fn(),
 };
 
-vi.mock('@visactor/vchart', () => ({
-  VChart: vi.fn().mockImplementation(() => mockVChart),
+vi.mock('@visactor/vtable-gantt', () => ({
+  Gantt: vi.fn().mockImplementation(() => mockGantt),
 }));
 
 // Mock selectSvgElement
 vi.mock('../../rendering-util/selectSvgElement.js', () => ({
   selectSvgElement: vi.fn().mockReturnValue({
-    append: vi.fn().mockReturnValue({
-      attr: vi.fn().mockReturnThis(),
-      style: vi.fn().mockReturnThis(),
-      node: vi.fn().mockReturnValue(document.createElement('div')),
+    node: vi.fn().mockReturnValue({
+      parentElement: document.createElement('div'),
+      nextSibling: null,
     }),
   }),
 }));
@@ -141,15 +140,15 @@ gantt
     里程碑1  :milestone, milestone1, 2024-01-08, 0d
     `;
 
-    await expect(drawWithVChart(text, 'gantt-test', '1.0.0', mockDiagObj)).resolves.not.toThrow();
+    await expect(drawWithVTable(text, 'gantt-test', '1.0.0', mockDiagObj)).resolves.not.toThrow();
 
-    expect(mockVChart.renderAsync).toHaveBeenCalled();
+    expect(mockGantt.render).toHaveBeenCalled();
   });
 
   it('应该正确提取甘特图数据', async () => {
     const text = 'gantt\n    title 测试甘特图';
 
-    await drawWithVChart(text, 'gantt-test', '1.0.0', mockDiagObj);
+    await drawWithVTable(text, 'gantt-test', '1.0.0', mockDiagObj);
 
     expect(mockDb.getTasks).toHaveBeenCalled();
     expect(mockDb.getSections).toHaveBeenCalled();
@@ -170,17 +169,17 @@ gantt
     };
 
     await expect(
-      drawWithVChart('gantt', 'gantt-empty', '1.0.0', emptyDiagObj)
+      drawWithVTable('gantt', 'gantt-empty', '1.0.0', emptyDiagObj)
     ).resolves.not.toThrow();
   });
 
   it('应该正确应用主题变量', async () => {
     const text = 'gantt\n    title 主题测试';
 
-    await drawWithVChart(text, 'gantt-theme', '1.0.0', mockDiagObj);
+    await drawWithVTable(text, 'gantt-theme', '1.0.0', mockDiagObj);
 
     // VChart应该被调用并传入正确的规格
-    expect(mockVChart.renderAsync).toHaveBeenCalled();
+    expect(mockGantt.render).toHaveBeenCalled();
   });
 
   it('应该处理不同类型的任务', async () => {
@@ -266,10 +265,10 @@ gantt
     };
 
     await expect(
-      drawWithVChart('gantt', 'gantt-mixed', '1.0.0', mixedDiagObj)
+      drawWithVTable('gantt', 'gantt-mixed', '1.0.0', mixedDiagObj)
     ).resolves.not.toThrow();
 
-    expect(mockVChart.renderAsync).toHaveBeenCalled();
+    expect(mockGantt.render).toHaveBeenCalled();
   });
 
   it('应该正确处理时间间隔配置', async () => {
@@ -284,7 +283,7 @@ gantt
     };
 
     await expect(
-      drawWithVChart('gantt', 'gantt-interval', '1.0.0', intervalDiagObj)
+      drawWithVTable('gantt', 'gantt-interval', '1.0.0', intervalDiagObj)
     ).resolves.not.toThrow();
 
     expect(intervalDb.getTickInterval).toHaveBeenCalled();
@@ -302,18 +301,18 @@ gantt
     };
 
     await expect(
-      drawWithVChart('gantt', 'gantt-error', '1.0.0', errorDiagObj)
+      drawWithVTable('gantt', 'gantt-error', '1.0.0', errorDiagObj)
     ).resolves.not.toThrow();
   });
 
   it('应该清理VChart资源', async () => {
     const text = 'gantt\n    title 资源清理测试';
 
-    await drawWithVChart(text, 'gantt-cleanup', '1.0.0', mockDiagObj);
+    await drawWithVTable(text, 'gantt-cleanup', '1.0.0', mockDiagObj);
 
     // 渲染器应该调用dispose方法来清理资源
     // 这里我们验证VChart实例已经被创建
-    expect(mockVChart.renderAsync).toHaveBeenCalled();
+    expect(mockGantt.render).toHaveBeenCalled();
   });
 
   it('应该支持自定义尺寸', async () => {
@@ -331,9 +330,9 @@ gantt
     };
 
     await expect(
-      drawWithVChart('gantt', 'gantt-custom-size', '1.0.0', customDiagObj)
+      drawWithVTable('gantt', 'gantt-custom-size', '1.0.0', customDiagObj)
     ).resolves.not.toThrow();
 
-    expect(mockVChart.renderAsync).toHaveBeenCalled();
+    expect(mockGantt.render).toHaveBeenCalled();
   });
 });

--- a/packages/mermaid/src/diagrams/gantt/ganttVChartRenderer.ts
+++ b/packages/mermaid/src/diagrams/gantt/ganttVChartRenderer.ts
@@ -1,0 +1,686 @@
+import type { DrawDefinition } from '../../diagram-api/types.js';
+import { getConfig } from '../../diagram-api/diagramAPI.js';
+import { log } from '../../logger.js';
+import { VChartRenderer } from '../../rendering-util/VChartRenderer.js';
+import { cleanAndMerge } from '../../utils.js';
+
+/**
+ * 甘特图任务数据接口
+ */
+interface GanttTask {
+  id: string;
+  task: string;
+  section: string;
+  startTime: Date;
+  endTime: Date;
+  renderEndTime?: Date | null;
+  active?: boolean;
+  done?: boolean;
+  crit?: boolean;
+  milestone?: boolean;
+  classes: string[];
+  order: number;
+}
+
+/**
+ * 甘特图数据库接口
+ */
+interface GanttDB {
+  getTasks(): GanttTask[];
+  getSections(): string[];
+  getDiagramTitle(): string;
+  getDateFormat(): string;
+  getAxisFormat(): string;
+  getTickInterval(): string;
+  getConfig(): GanttConfig;
+}
+
+/**
+ * 甘特图配置接口
+ */
+interface GanttConfig {
+  useWidth?: number;
+  renderer?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * VChart甘特图数据项接口
+ */
+interface VChartGanttDataItem {
+  id: string;
+  name: string;
+  section: string;
+  start: number;
+  end: number;
+  duration: number;
+  progress: number;
+  type: string;
+  row: number;
+  order: number;
+  classes: string[];
+  taskName: string;
+  startDate: number;
+  endDate: number;
+  group: string;
+  status: string;
+}
+
+/**
+ * 提取的甘特图数据接口
+ */
+interface ExtractedGanttData {
+  tasks: VChartGanttDataItem[];
+  sections: string[];
+  title: string;
+  dateFormat: string;
+  axisFormat: string;
+  tickInterval: string;
+  config: GanttConfig;
+}
+
+/**
+ * 时间轴刻度配置接口
+ */
+interface TimeAxisTick {
+  count: number;
+  unit: string;
+}
+
+/**
+ * VChart规格接口
+ */
+interface VChartSpec {
+  type: string;
+  data: {
+    id: string;
+    values: VChartGanttDataItem[];
+  }[];
+  taskField: string;
+  startField: string;
+  endField: string;
+  progressField: string;
+  groupField: string;
+  timeAxis: {
+    orient: string;
+    type: string;
+    min: number;
+    max: number;
+    tick: TimeAxisTick;
+    label: {
+      formatMethod: (value: number) => string;
+    };
+  };
+  groupAxis: {
+    orient: string;
+    type: string;
+    domain: string[];
+    tick: { visible: boolean };
+    grid: {
+      visible: boolean;
+      style: { stroke: string; lineWidth: number };
+    };
+  };
+  task: {
+    style: {
+      fill: (datum: VChartGanttDataItem) => string;
+      stroke: string;
+      strokeWidth: number;
+      cornerRadius: number;
+    };
+    state: {
+      hover: {
+        stroke: string;
+        strokeWidth: number;
+      };
+    };
+  };
+  progress: {
+    visible: boolean;
+    style: {
+      fill: string;
+      fillOpacity: number;
+    };
+  };
+  milestone: {
+    visible: boolean;
+    style: {
+      symbolType: string;
+      size: number;
+      fill: string;
+      stroke: string;
+      strokeWidth: number;
+    };
+  };
+  label: {
+    visible: boolean;
+    position: string;
+    style: {
+      fontSize: number;
+      fill: string;
+      fontWeight: string;
+    };
+    formatMethod: (datum: VChartGanttDataItem) => string;
+  };
+  grid: {
+    visible: boolean;
+    style: {
+      stroke: string;
+      strokeOpacity: number;
+    };
+  };
+  tooltip: {
+    visible: boolean;
+    mark: {
+      content: {
+        key: string;
+        value: (datum: VChartGanttDataItem) => string;
+      }[];
+    };
+  };
+  animation: {
+    appear: {
+      duration: number;
+      easing: string;
+    };
+    enter: {
+      type: string;
+      duration: number;
+    };
+  };
+  interaction: {
+    brush: {
+      visible: boolean;
+      brushType: string;
+    };
+    zoom: {
+      visible: boolean;
+      zoomType: string;
+    };
+  };
+  title?: {
+    visible: boolean;
+    text: string;
+    align: string;
+    style: {
+      fontSize: number;
+      fontWeight: string;
+      fontFamily?: string;
+      [key: string]: unknown;
+    };
+  };
+  background?: string;
+}
+
+/**
+ * 主题变量接口
+ */
+interface ThemeVariables {
+  fontFamily?: string;
+  doneTaskBkgColor?: string;
+  activeTaskBkgColor?: string;
+  critBkgColor?: string;
+  taskBkgColor?: string;
+  gridColor?: string;
+  background?: string;
+}
+
+/**
+ * 甘特图VChart渲染器实现
+ */
+class GanttVChartRenderer extends VChartRenderer {
+  /**
+   * 从数据库提取甘特图数据
+   */
+  protected extractData(db: GanttDB): ExtractedGanttData {
+    const tasks: GanttTask[] = db.getTasks();
+    const sections: string[] = db.getSections();
+    const title = db.getDiagramTitle();
+
+    log.debug('Gantt chart data:', { tasks, sections, title });
+
+    // 转换任务数据为VChart期望的格式
+    const chartData = tasks.map((task) => {
+      const startTime = new Date(task.startTime).getTime();
+      const endTime = new Date(task.renderEndTime || task.endTime).getTime();
+      const duration = endTime - startTime;
+
+      return {
+        id: task.id,
+        name: task.task,
+        section: task.section,
+        start: startTime,
+        end: endTime,
+        duration: duration,
+        progress: task.done ? 1 : task.active ? 0.5 : 0,
+        type: this.getTaskType(task),
+        row: this.getTaskRow(task, sections),
+        order: task.order,
+        classes: task.classes,
+        // VChart甘特图需要的字段
+        taskName: task.task,
+        startDate: startTime,
+        endDate: endTime,
+        group: task.section,
+        status: this.getTaskStatus(task),
+      };
+    });
+
+    return {
+      tasks: chartData,
+      sections,
+      title,
+      dateFormat: db.getDateFormat(),
+      axisFormat: db.getAxisFormat(),
+      tickInterval: db.getTickInterval(),
+      config: db.getConfig(),
+    };
+  }
+
+  /**
+   * 获取任务类型
+   */
+  private getTaskType(task: GanttTask): string {
+    if (task.milestone) {
+      return 'milestone';
+    }
+    if (task.crit) {
+      return 'critical';
+    }
+    if (task.active) {
+      return 'active';
+    }
+    if (task.done) {
+      return 'done';
+    }
+    return 'normal';
+  }
+
+  /**
+   * 获取任务状态
+   */
+  private getTaskStatus(task: GanttTask): string {
+    if (task.done) {
+      return 'done';
+    }
+    if (task.active) {
+      return 'active';
+    }
+    if (task.crit) {
+      return 'critical';
+    }
+    return 'normal';
+  }
+
+  /**
+   * 获取任务所在行
+   */
+  private getTaskRow(task: GanttTask, sections: string[]): number {
+    const sectionIndex = sections.indexOf(task.section);
+    return sectionIndex >= 0 ? sectionIndex : 0;
+  }
+
+  /**
+   * 创建VChart甘特图规格
+   */
+  protected createVChartSpec(data: ExtractedGanttData, _config: GanttConfig): VChartSpec {
+    const { tasks, sections, title } = data;
+
+    if (!tasks || tasks.length === 0) {
+      log.warn('No tasks found for Gantt chart');
+      return this.createEmptySpec() as VChartSpec;
+    }
+
+    // 计算时间范围
+    const startTimes = tasks.map((task) => task.start);
+    const endTimes = tasks.map((task) => task.end);
+    const minTime = Math.min(...startTimes);
+    const maxTime = Math.max(...endTimes);
+
+    // 创建VChart甘特图规格
+    const spec = {
+      type: 'common',
+      data: [
+        {
+          id: 'ganttData',
+          values: tasks,
+        },
+      ],
+      // 甘特图字段映射
+      taskField: 'taskName',
+      startField: 'startDate',
+      endField: 'endDate',
+      progressField: 'progress',
+      groupField: 'group',
+
+      // 时间轴配置
+      timeAxis: {
+        orient: 'bottom',
+        type: 'time',
+        min: minTime,
+        max: maxTime,
+        tick: this.createTimeAxisTick(data),
+        label: {
+          formatMethod: (value: number) => {
+            return new Date(value).toLocaleDateString();
+          },
+        },
+      },
+
+      // 分组轴配置
+      groupAxis: {
+        orient: 'left',
+        type: 'band',
+        domain: sections,
+        tick: {
+          visible: false,
+        },
+        grid: {
+          visible: true,
+          style: {
+            stroke: '#e8e8e8',
+            lineWidth: 1,
+          },
+        },
+      },
+
+      // 任务条样式
+      task: {
+        style: {
+          fill: (datum: VChartGanttDataItem) => this.getTaskColor(datum),
+          stroke: '#fff',
+          strokeWidth: 1,
+          cornerRadius: 2,
+        },
+        state: {
+          hover: {
+            stroke: '#333',
+            strokeWidth: 2,
+          },
+        },
+      },
+
+      // 进度条样式
+      progress: {
+        visible: true,
+        style: {
+          fill: '#4CAF50',
+          fillOpacity: 0.8,
+        },
+      },
+
+      // 里程碑样式
+      milestone: {
+        visible: true,
+        style: {
+          symbolType: 'diamond',
+          size: 8,
+          fill: '#FF9800',
+          stroke: '#fff',
+          strokeWidth: 2,
+        },
+      },
+
+      // 标签配置
+      label: {
+        visible: true,
+        position: 'inside',
+        style: {
+          fontSize: 12,
+          fill: '#fff',
+          fontWeight: 'normal',
+        },
+        formatMethod: (datum: VChartGanttDataItem) => {
+          return datum.taskName;
+        },
+      },
+
+      // 网格线配置
+      grid: {
+        visible: true,
+        style: {
+          stroke: '#e8e8e8',
+          strokeOpacity: 0.5,
+        },
+      },
+
+      // 工具提示
+      tooltip: {
+        visible: true,
+        mark: {
+          content: [
+            {
+              key: '任务',
+              value: (datum: VChartGanttDataItem) => datum.taskName,
+            },
+            {
+              key: '开始时间',
+              value: (datum: VChartGanttDataItem) => new Date(datum.startDate).toLocaleDateString(),
+            },
+            {
+              key: '结束时间',
+              value: (datum: VChartGanttDataItem) => new Date(datum.endDate).toLocaleDateString(),
+            },
+            {
+              key: '进度',
+              value: (datum: VChartGanttDataItem) => `${Math.round(datum.progress * 100)}%`,
+            },
+            {
+              key: '状态',
+              value: (datum: VChartGanttDataItem) => datum.status,
+            },
+          ],
+        },
+      },
+
+      // 动画配置
+      animation: {
+        appear: {
+          duration: 1000,
+          easing: 'cubicOut',
+        },
+        enter: {
+          type: 'fadeIn',
+          duration: 500,
+        },
+      },
+
+      // 交互配置
+      interaction: {
+        brush: {
+          visible: true,
+          brushType: 'x',
+        },
+        zoom: {
+          visible: true,
+          zoomType: 'x',
+        },
+      },
+    };
+
+    // 添加标题
+    if (title) {
+      (spec as Record<string, unknown>).title = {
+        visible: true,
+        text: title,
+        align: 'center',
+        style: {
+          fontSize: 16,
+          fontWeight: 'bold',
+        },
+      };
+    }
+
+    log.debug('Generated VChart Gantt spec:', spec);
+    return spec;
+  }
+
+  /**
+   * 创建时间轴刻度配置
+   */
+  private createTimeAxisTick(data: ExtractedGanttData): TimeAxisTick {
+    const tickInterval = data.tickInterval;
+    if (tickInterval) {
+      // 解析tickInterval格式，如 "1day", "1week" 等
+      const match = /^(\d+)(day|week|month|year)$/.exec(tickInterval);
+      if (match) {
+        const count = parseInt(match[1]);
+        const unit = match[2];
+
+        return {
+          count,
+          unit,
+        };
+      }
+    }
+
+    return {
+      count: 1,
+      unit: 'day',
+    };
+  }
+
+  /**
+   * 获取任务颜色
+   */
+  private getTaskColor(datum: VChartGanttDataItem): string {
+    switch (datum.status) {
+      case 'done':
+        return '#4CAF50'; // 绿色
+      case 'active':
+        return '#2196F3'; // 蓝色
+      case 'critical':
+        return '#F44336'; // 红色
+      default:
+        return '#9E9E9E'; // 灰色
+    }
+  }
+
+  /**
+   * 创建空的图表规格
+   */
+  private createEmptySpec(): Partial<VChartSpec> {
+    return {
+      type: 'gantt',
+      data: [
+        {
+          id: 'ganttData',
+          values: [],
+        },
+      ],
+      title: {
+        visible: true,
+        text: '无数据',
+        align: 'center',
+        style: {
+          fontSize: 14,
+          fontWeight: 'normal',
+        },
+      },
+    };
+  }
+
+  /**
+   * 应用mermaid主题到VChart
+   */
+  protected applyTheme(spec: VChartSpec, themeVariables: ThemeVariables): VChartSpec {
+    if (!themeVariables) {
+      return spec;
+    }
+
+    // 应用颜色主题
+    const colorScheme = {
+      done: themeVariables.doneTaskBkgColor || '#4CAF50',
+      active: themeVariables.activeTaskBkgColor || '#2196F3',
+      critical: themeVariables.critBkgColor || '#F44336',
+      normal: themeVariables.taskBkgColor || '#9E9E9E',
+    };
+
+    // 更新任务样式
+    spec.task = {
+      ...spec.task,
+      style: {
+        ...spec.task?.style,
+        fill: (datum: VChartGanttDataItem) =>
+          colorScheme[datum.status as keyof typeof colorScheme] || colorScheme.normal,
+      },
+    };
+
+    // 应用字体配置
+    if (themeVariables.fontFamily) {
+      spec.label = {
+        ...spec.label,
+        style: {
+          ...spec.label?.style,
+          fontFamily: themeVariables.fontFamily,
+        } as typeof spec.label.style & { fontFamily?: string },
+      };
+
+      if (spec.title) {
+        spec.title.style = {
+          ...spec.title.style,
+          fontFamily: themeVariables.fontFamily,
+        } as typeof spec.title.style & { fontFamily?: string };
+      }
+    }
+
+    // 应用网格颜色
+    if (themeVariables.gridColor) {
+      spec.grid = {
+        ...spec.grid,
+        style: {
+          ...spec.grid?.style,
+          stroke: themeVariables.gridColor,
+        },
+      };
+    }
+
+    // 应用背景色
+    if (themeVariables.background) {
+      spec.background = themeVariables.background;
+    }
+
+    return spec;
+  }
+}
+
+/**
+ * VChart甘特图绘制函数
+ */
+const drawWithVChart: DrawDefinition = async (text, id, _version, diagObj) => {
+  log.debug('rendering gantt chart with VChart\n' + text);
+
+  const db = diagObj.db;
+  const globalConfig = getConfig();
+  const ganttConfig = cleanAndMerge(db.getConfig ? db.getConfig() : {}, globalConfig.gantt || {});
+
+  const renderer = new GanttVChartRenderer();
+
+  try {
+    // 设置图表尺寸
+    const width = ganttConfig?.useWidth || 1200;
+    const height = 600;
+
+    // 渲染图表
+    await renderer.render(
+      text,
+      id,
+      _version,
+      {
+        ...diagObj,
+        globalConfig,
+      },
+      width,
+      height
+    );
+
+    log.debug('Gantt chart rendered successfully with VChart');
+  } catch (error) {
+    log.error('Failed to render gantt chart with VChart:', error);
+    throw error;
+  } finally {
+    renderer.dispose();
+  }
+};
+
+export { drawWithVChart };

--- a/packages/mermaid/src/diagrams/gantt/ganttVChartRenderer.ts
+++ b/packages/mermaid/src/diagrams/gantt/ganttVChartRenderer.ts
@@ -1,8 +1,9 @@
 import type { DrawDefinition } from '../../diagram-api/types.js';
 import { getConfig } from '../../diagram-api/diagramAPI.js';
 import { log } from '../../logger.js';
-import { VChartRenderer } from '../../rendering-util/VChartRenderer.js';
 import { cleanAndMerge } from '../../utils.js';
+import { selectSvgElement } from '../../rendering-util/selectSvgElement.js';
+import { configureSvgSize } from '../../setupGraphViewbox.js';
 
 /**
  * 甘特图任务数据接口
@@ -45,32 +46,31 @@ interface GanttConfig {
 }
 
 /**
- * VChart甘特图数据项接口
+ * VTable甘特图数据项接口
  */
-interface VChartGanttDataItem {
+interface VTableGanttDataItem {
   id: string;
-  name: string;
+  taskName: string;
   section: string;
-  start: number;
-  end: number;
+  startTime: string;
+  endTime: string;
   duration: number;
   progress: number;
   type: string;
-  row: number;
   order: number;
   classes: string[];
-  taskName: string;
-  startDate: number;
-  endDate: number;
-  group: string;
   status: string;
+  done: boolean;
+  active: boolean;
+  crit: boolean;
+  milestone: boolean;
 }
 
 /**
  * 提取的甘特图数据接口
  */
 interface ExtractedGanttData {
-  tasks: VChartGanttDataItem[];
+  tasks: VTableGanttDataItem[];
   sections: string[];
   title: string;
   dateFormat: string;
@@ -80,136 +80,74 @@ interface ExtractedGanttData {
 }
 
 /**
- * 时间轴刻度配置接口
+ * VTable甘特图配置接口
  */
-interface TimeAxisTick {
-  count: number;
-  unit: string;
-}
-
-/**
- * VChart规格接口
- */
-interface VChartSpec {
-  type: string;
-  data: {
-    id: string;
-    values: VChartGanttDataItem[];
+interface VTableGanttConfig {
+  container?: string | HTMLElement;
+  data: VTableGanttDataItem[];
+  columns: {
+    title: string;
+    field: string;
+    width?: number;
+    style?: {
+      color?: string;
+      bgColor?: string;
+      fontWeight?: string;
+    };
   }[];
-  taskField: string;
-  startField: string;
-  endField: string;
-  progressField: string;
-  groupField: string;
-  timeAxis: {
-    orient: string;
-    type: string;
-    min: number;
-    max: number;
-    tick: TimeAxisTick;
-    label: {
-      formatMethod: (value: number) => string;
-    };
+  timeLineHeader: {
+    scales: {
+      unit: 'day' | 'week' | 'month' | 'year';
+      step: number;
+      label: string;
+    }[];
   };
-  groupAxis: {
-    orient: string;
-    type: string;
-    domain: string[];
-    tick: { visible: boolean };
-    grid: {
-      visible: boolean;
-      style: { stroke: string; lineWidth: number };
-    };
-  };
-  task: {
-    style: {
-      fill: (datum: VChartGanttDataItem) => string;
-      stroke: string;
-      strokeWidth: number;
-      cornerRadius: number;
-    };
-    state: {
-      hover: {
-        stroke: string;
-        strokeWidth: number;
+  gantt: {
+    taskField: string;
+    startField: string;
+    endField: string;
+    progressField: string;
+    groupField: string;
+    style?: {
+      taskBar?: {
+        fill?: (datum: VTableGanttDataItem) => string;
+        stroke?: string;
+        strokeWidth?: number;
+        cornerRadius?: number;
       };
-    };
-  };
-  progress: {
-    visible: boolean;
-    style: {
-      fill: string;
-      fillOpacity: number;
-    };
-  };
-  milestone: {
-    visible: boolean;
-    style: {
-      symbolType: string;
-      size: number;
-      fill: string;
-      stroke: string;
-      strokeWidth: number;
-    };
-  };
-  label: {
-    visible: boolean;
-    position: string;
-    style: {
-      fontSize: number;
-      fill: string;
-      fontWeight: string;
-    };
-    formatMethod: (datum: VChartGanttDataItem) => string;
-  };
-  grid: {
-    visible: boolean;
-    style: {
-      stroke: string;
-      strokeOpacity: number;
-    };
-  };
-  tooltip: {
-    visible: boolean;
-    mark: {
-      content: {
-        key: string;
-        value: (datum: VChartGanttDataItem) => string;
-      }[];
-    };
-  };
-  animation: {
-    appear: {
-      duration: number;
-      easing: string;
-    };
-    enter: {
-      type: string;
-      duration: number;
-    };
-  };
-  interaction: {
-    brush: {
-      visible: boolean;
-      brushType: string;
-    };
-    zoom: {
-      visible: boolean;
-      zoomType: string;
+      progressBar?: {
+        fill?: string;
+        fillOpacity?: number;
+      };
+      milestone?: {
+        symbolType?: string;
+        size?: number;
+        fill?: string;
+        stroke?: string;
+        strokeWidth?: number;
+      };
     };
   };
   title?: {
     visible: boolean;
     text: string;
-    align: string;
-    style: {
-      fontSize: number;
-      fontWeight: string;
+    align: 'left' | 'center' | 'right';
+    style?: {
+      fontSize?: number;
+      fontWeight?: string;
       fontFamily?: string;
-      [key: string]: unknown;
+      color?: string;
     };
   };
-  background?: string;
+  theme?: {
+    fontFamily?: string;
+    colorScheme?: {
+      done?: string;
+      active?: string;
+      critical?: string;
+      normal?: string;
+    };
+  };
 }
 
 /**
@@ -226,9 +164,11 @@ interface ThemeVariables {
 }
 
 /**
- * 甘特图VChart渲染器实现
+ * 甘特图VTable渲染器实现
  */
-class GanttVChartRenderer extends VChartRenderer {
+class GanttVTableRenderer {
+  private gantt: unknown = null;
+  private container: HTMLElement | null = null;
   /**
    * 从数据库提取甘特图数据
    */
@@ -239,30 +179,29 @@ class GanttVChartRenderer extends VChartRenderer {
 
     log.debug('Gantt chart data:', { tasks, sections, title });
 
-    // 转换任务数据为VChart期望的格式
+    // 转换任务数据为VTable期望的格式
     const chartData = tasks.map((task) => {
-      const startTime = new Date(task.startTime).getTime();
-      const endTime = new Date(task.renderEndTime || task.endTime).getTime();
-      const duration = endTime - startTime;
+      const startTime = new Date(task.startTime).toISOString().split('T')[0];
+      const endTime = new Date(task.renderEndTime ?? task.endTime).toISOString().split('T')[0];
+      const duration =
+        new Date(task.renderEndTime ?? task.endTime).getTime() - new Date(task.startTime).getTime();
 
       return {
         id: task.id,
-        name: task.task,
+        taskName: task.task,
         section: task.section,
-        start: startTime,
-        end: endTime,
+        startTime: startTime,
+        endTime: endTime,
         duration: duration,
         progress: task.done ? 1 : task.active ? 0.5 : 0,
         type: this.getTaskType(task),
-        row: this.getTaskRow(task, sections),
         order: task.order,
         classes: task.classes,
-        // VChart甘特图需要的字段
-        taskName: task.task,
-        startDate: startTime,
-        endDate: endTime,
-        group: task.section,
         status: this.getTaskStatus(task),
+        done: task.done ?? false,
+        active: task.active ?? false,
+        crit: task.crit ?? false,
+        milestone: task.milestone ?? false,
       };
     });
 
@@ -313,194 +252,118 @@ class GanttVChartRenderer extends VChartRenderer {
   }
 
   /**
-   * 获取任务所在行
+   * 初始化VTable容器
    */
-  private getTaskRow(task: GanttTask, sections: string[]): number {
-    const sectionIndex = sections.indexOf(task.section);
-    return sectionIndex >= 0 ? sectionIndex : 0;
+  protected initContainer(id: string): HTMLElement {
+    const svg = selectSvgElement(id);
+    const svgNode = svg.node() as unknown as SVGElement | null;
+    const parent = svgNode?.parentElement as HTMLElement | null;
+
+    // 在 SVG 父容器中创建标准 HTML div，避免 foreignObject 导致的 appendChild 问题
+    const container = document.createElement('div');
+    container.style.width = '100%';
+    container.style.height = '100%';
+    container.style.position = 'relative';
+
+    // 将容器插入到 svg 之后，作为同级元素
+    if (parent) {
+      parent.insertBefore(container, svgNode?.nextSibling ?? null);
+    } else {
+      // 兜底：若未找到父元素，则附加到 body
+      document.body.appendChild(container);
+    }
+
+    this.container = container;
+    return container;
   }
 
   /**
-   * 创建VChart甘特图规格
+   * 创建VTable甘特图配置
    */
-  protected createVChartSpec(data: ExtractedGanttData, _config: GanttConfig): VChartSpec {
-    const { tasks, sections, title } = data;
+  protected createVTableConfig(data: ExtractedGanttData, _config: GanttConfig): VTableGanttConfig {
+    const { tasks, title } = data;
 
     if (!tasks || tasks.length === 0) {
       log.warn('No tasks found for Gantt chart');
-      return this.createEmptySpec() as VChartSpec;
+      return this.createEmptyConfig();
     }
 
-    // 计算时间范围
-    const startTimes = tasks.map((task) => task.start);
-    const endTimes = tasks.map((task) => task.end);
-    const minTime = Math.min(...startTimes);
-    const maxTime = Math.max(...endTimes);
-
-    // 创建VChart甘特图规格
-    const spec = {
-      type: 'common',
-      data: [
+    // 创建VTable甘特图配置
+    const config: VTableGanttConfig = {
+      data: tasks,
+      columns: [
         {
-          id: 'ganttData',
-          values: tasks,
+          title: '任务名称',
+          field: 'taskName',
+          width: 200,
+          style: {
+            fontWeight: 'bold',
+          },
+        },
+        {
+          title: '分组',
+          field: 'section',
+          width: 120,
+        },
+        {
+          title: '开始时间',
+          field: 'startTime',
+          width: 120,
+        },
+        {
+          title: '结束时间',
+          field: 'endTime',
+          width: 120,
+        },
+        {
+          title: '进度',
+          field: 'progress',
+          width: 80,
+        },
+        {
+          title: '状态',
+          field: 'status',
+          width: 80,
         },
       ],
-      // 甘特图字段映射
-      taskField: 'taskName',
-      startField: 'startDate',
-      endField: 'endDate',
-      progressField: 'progress',
-      groupField: 'group',
-
-      // 时间轴配置
-      timeAxis: {
-        orient: 'bottom',
-        type: 'time',
-        min: minTime,
-        max: maxTime,
-        tick: this.createTimeAxisTick(data),
-        label: {
-          formatMethod: (value: number) => {
-            return new Date(value).toLocaleDateString();
-          },
-        },
+      timeLineHeader: {
+        scales: [
+          { unit: 'day', step: 1, label: '日' },
+          { unit: 'week', step: 1, label: '周' },
+          { unit: 'month', step: 1, label: '月' },
+        ],
       },
-
-      // 分组轴配置
-      groupAxis: {
-        orient: 'left',
-        type: 'band',
-        domain: sections,
-        tick: {
-          visible: false,
-        },
-        grid: {
-          visible: true,
-          style: {
-            stroke: '#e8e8e8',
-            lineWidth: 1,
-          },
-        },
-      },
-
-      // 任务条样式
-      task: {
+      gantt: {
+        taskField: 'taskName',
+        startField: 'startTime',
+        endField: 'endTime',
+        progressField: 'progress',
+        groupField: 'section',
         style: {
-          fill: (datum: VChartGanttDataItem) => this.getTaskColor(datum),
-          stroke: '#fff',
-          strokeWidth: 1,
-          cornerRadius: 2,
-        },
-        state: {
-          hover: {
-            stroke: '#333',
+          taskBar: {
+            fill: (datum: VTableGanttDataItem) => this.getTaskColor(datum),
+            stroke: '#fff',
+            strokeWidth: 1,
+            cornerRadius: 2,
+          },
+          progressBar: {
+            fill: '#4CAF50',
+            fillOpacity: 0.8,
+          },
+          milestone: {
+            symbolType: 'diamond',
+            size: 8,
+            fill: '#FF9800',
+            stroke: '#fff',
             strokeWidth: 2,
           },
-        },
-      },
-
-      // 进度条样式
-      progress: {
-        visible: true,
-        style: {
-          fill: '#4CAF50',
-          fillOpacity: 0.8,
-        },
-      },
-
-      // 里程碑样式
-      milestone: {
-        visible: true,
-        style: {
-          symbolType: 'diamond',
-          size: 8,
-          fill: '#FF9800',
-          stroke: '#fff',
-          strokeWidth: 2,
-        },
-      },
-
-      // 标签配置
-      label: {
-        visible: true,
-        position: 'inside',
-        style: {
-          fontSize: 12,
-          fill: '#fff',
-          fontWeight: 'normal',
-        },
-        formatMethod: (datum: VChartGanttDataItem) => {
-          return datum.taskName;
-        },
-      },
-
-      // 网格线配置
-      grid: {
-        visible: true,
-        style: {
-          stroke: '#e8e8e8',
-          strokeOpacity: 0.5,
-        },
-      },
-
-      // 工具提示
-      tooltip: {
-        visible: true,
-        mark: {
-          content: [
-            {
-              key: '任务',
-              value: (datum: VChartGanttDataItem) => datum.taskName,
-            },
-            {
-              key: '开始时间',
-              value: (datum: VChartGanttDataItem) => new Date(datum.startDate).toLocaleDateString(),
-            },
-            {
-              key: '结束时间',
-              value: (datum: VChartGanttDataItem) => new Date(datum.endDate).toLocaleDateString(),
-            },
-            {
-              key: '进度',
-              value: (datum: VChartGanttDataItem) => `${Math.round(datum.progress * 100)}%`,
-            },
-            {
-              key: '状态',
-              value: (datum: VChartGanttDataItem) => datum.status,
-            },
-          ],
-        },
-      },
-
-      // 动画配置
-      animation: {
-        appear: {
-          duration: 1000,
-          easing: 'cubicOut',
-        },
-        enter: {
-          type: 'fadeIn',
-          duration: 500,
-        },
-      },
-
-      // 交互配置
-      interaction: {
-        brush: {
-          visible: true,
-          brushType: 'x',
-        },
-        zoom: {
-          visible: true,
-          zoomType: 'x',
         },
       },
     };
 
     // 添加标题
     if (title) {
-      (spec as Record<string, unknown>).title = {
+      config.title = {
         visible: true,
         text: title,
         align: 'center',
@@ -511,39 +374,54 @@ class GanttVChartRenderer extends VChartRenderer {
       };
     }
 
-    log.debug('Generated VChart Gantt spec:', spec);
-    return spec;
+    log.debug('Generated VTable Gantt config:', config);
+    return config;
   }
 
   /**
-   * 创建时间轴刻度配置
+   * 渲染VTable甘特图
    */
-  private createTimeAxisTick(data: ExtractedGanttData): TimeAxisTick {
-    const tickInterval = data.tickInterval;
-    if (tickInterval) {
-      // 解析tickInterval格式，如 "1day", "1week" 等
-      const match = /^(\d+)(day|week|month|year)$/.exec(tickInterval);
-      if (match) {
-        const count = parseInt(match[1]);
-        const unit = match[2];
+  protected async renderVTable(
+    config: VTableGanttConfig,
+    container: HTMLElement,
+    width: number,
+    height: number
+  ): Promise<unknown> {
+    try {
+      // 动态导入VTable Gantt
+      const { Gantt } = await import('@visactor/vtable-gantt');
 
-        return {
-          count,
-          unit,
-        };
+      // 设置容器尺寸
+      container.style.width = `${width}px`;
+      container.style.height = `${height}px`;
+
+      // 创建VTable甘特图实例
+      // VTable Gantt 构造函数期望第一个参数是容器元素，第二个参数是配置对象
+      this.gantt = new Gantt(container, {
+        ...config,
+        width,
+        height,
+        timelineHeader: config.timeLineHeader,
+      } as any);
+
+      // 渲染甘特图（某些版本构造后即自动渲染，render 可能不存在）
+      const maybeRender = (this.gantt as any)?.render;
+      if (typeof maybeRender === 'function') {
+        maybeRender.call(this.gantt);
       }
-    }
 
-    return {
-      count: 1,
-      unit: 'day',
-    };
+      log.debug('VTable Gantt rendered successfully');
+      return this.gantt;
+    } catch (error) {
+      log.error('Failed to render VTable Gantt:', error);
+      throw new Error(`VTable Gantt rendering failed: ${String(error)}`);
+    }
   }
 
   /**
    * 获取任务颜色
    */
-  private getTaskColor(datum: VChartGanttDataItem): string {
+  private getTaskColor(datum: VTableGanttDataItem): string {
     switch (datum.status) {
       case 'done':
         return '#4CAF50'; // 绿色
@@ -557,17 +435,28 @@ class GanttVChartRenderer extends VChartRenderer {
   }
 
   /**
-   * 创建空的图表规格
+   * 创建空的甘特图配置
    */
-  private createEmptySpec(): Partial<VChartSpec> {
+  private createEmptyConfig(): VTableGanttConfig {
     return {
-      type: 'gantt',
-      data: [
+      data: [],
+      columns: [
         {
-          id: 'ganttData',
-          values: [],
+          title: '任务名称',
+          field: 'taskName',
+          width: 200,
         },
       ],
+      timeLineHeader: {
+        scales: [{ unit: 'day', step: 1, label: '日' }],
+      },
+      gantt: {
+        taskField: 'taskName',
+        startField: 'startTime',
+        endField: 'endTime',
+        progressField: 'progress',
+        groupField: 'section',
+      },
       title: {
         visible: true,
         text: '无数据',
@@ -581,84 +470,125 @@ class GanttVChartRenderer extends VChartRenderer {
   }
 
   /**
-   * 应用mermaid主题到VChart
+   * 应用mermaid主题到VTable
    */
-  protected applyTheme(spec: VChartSpec, themeVariables: ThemeVariables): VChartSpec {
+  protected applyTheme(
+    config: VTableGanttConfig,
+    themeVariables: ThemeVariables
+  ): VTableGanttConfig {
     if (!themeVariables) {
-      return spec;
+      return config;
     }
 
     // 应用颜色主题
     const colorScheme = {
-      done: themeVariables.doneTaskBkgColor || '#4CAF50',
-      active: themeVariables.activeTaskBkgColor || '#2196F3',
-      critical: themeVariables.critBkgColor || '#F44336',
-      normal: themeVariables.taskBkgColor || '#9E9E9E',
+      done: themeVariables.doneTaskBkgColor ?? '#4CAF50',
+      active: themeVariables.activeTaskBkgColor ?? '#2196F3',
+      critical: themeVariables.critBkgColor ?? '#F44336',
+      normal: themeVariables.taskBkgColor ?? '#9E9E9E',
     };
 
-    // 更新任务样式
-    spec.task = {
-      ...spec.task,
-      style: {
-        ...spec.task?.style,
-        fill: (datum: VChartGanttDataItem) =>
-          colorScheme[datum.status as keyof typeof colorScheme] || colorScheme.normal,
-      },
-    };
+    // 更新任务条样式
+    if (config.gantt?.style?.taskBar) {
+      config.gantt.style.taskBar.fill = (datum: VTableGanttDataItem) =>
+        colorScheme[datum.status as keyof typeof colorScheme] ?? colorScheme.normal;
+    }
 
     // 应用字体配置
     if (themeVariables.fontFamily) {
-      spec.label = {
-        ...spec.label,
-        style: {
-          ...spec.label?.style,
-          fontFamily: themeVariables.fontFamily,
-        } as typeof spec.label.style & { fontFamily?: string },
+      config.theme = {
+        ...config.theme,
+        fontFamily: themeVariables.fontFamily,
       };
 
-      if (spec.title) {
-        spec.title.style = {
-          ...spec.title.style,
+      if (config.title) {
+        config.title.style = {
+          ...config.title.style,
           fontFamily: themeVariables.fontFamily,
-        } as typeof spec.title.style & { fontFamily?: string };
+        };
       }
     }
 
-    // 应用网格颜色
-    if (themeVariables.gridColor) {
-      spec.grid = {
-        ...spec.grid,
-        style: {
-          ...spec.grid?.style,
-          stroke: themeVariables.gridColor,
-        },
-      };
-    }
+    // 应用主题颜色方案
+    config.theme = {
+      ...config.theme,
+      colorScheme,
+    };
 
-    // 应用背景色
-    if (themeVariables.background) {
-      spec.background = themeVariables.background;
-    }
+    return config;
+  }
 
-    return spec;
+  /**
+   * 清理资源
+   */
+  public dispose(): void {
+    if (this.gantt) {
+      (this.gantt as any).release?.();
+      this.gantt = null;
+    }
+    this.container = null;
+  }
+
+  /**
+   * 通用的绘制方法模板
+   */
+  public async render(
+    text: string,
+    id: string,
+    _version: string,
+    diagObj: unknown,
+    width: number,
+    height: number
+  ): Promise<void> {
+    log.debug(`Rendering ${this.constructor.name} with VTable\n${text}`);
+
+    try {
+      // 获取数据和配置
+      const db = (diagObj as any).db;
+      const config = db.getConfig();
+      const data = this.extractData(db);
+
+      // 创建VTable甘特图配置
+      let ganttConfig = this.createVTableConfig(data, config);
+
+      // 应用主题
+      const { themeVariables } = (diagObj as any).globalConfig ?? {};
+      if (themeVariables) {
+        ganttConfig = this.applyTheme(ganttConfig, themeVariables);
+      }
+
+      // 初始化容器
+      const container = this.initContainer(id);
+
+      // 渲染甘特图
+      await this.renderVTable(ganttConfig, container, width, height);
+
+      // 配置SVG大小
+      const svg = selectSvgElement(id);
+      configureSvgSize(svg, height, width, config?.useMaxWidth);
+    } catch (error) {
+      log.error(`Failed to render ${this.constructor.name}:`, error);
+      // 回退到错误状态或默认渲染器
+      throw error;
+    }
   }
 }
 
 /**
- * VChart甘特图绘制函数
+ * VTable甘特图绘制函数
  */
-const drawWithVChart: DrawDefinition = async (text, id, _version, diagObj) => {
-  log.debug('rendering gantt chart with VChart\n' + text);
+const drawWithVTable: DrawDefinition = async (text, id, _version, diagObj) => {
+  log.debug('rendering gantt chart with VTable\n' + text);
 
   const db = diagObj.db;
   const globalConfig = getConfig();
-  const ganttConfig = cleanAndMerge(db.getConfig ? db.getConfig() : {}, globalConfig.gantt || {});
+  const ganttConfig = cleanAndMerge(db.getConfig ? db.getConfig() : {}, globalConfig.gantt ?? {});
 
-  const renderer = new GanttVChartRenderer();
+  const renderer = new GanttVTableRenderer();
 
   try {
     // 设置图表尺寸
-    const width = ganttConfig?.useWidth || 1200;
+    const width = ganttConfig?.useWidth ?? 1200;
     const height = 600;
 
     // 渲染图表
@@ -674,13 +604,13 @@ const drawWithVChart: DrawDefinition = async (text, id, _version, diagObj) => {
       height
     );
 
-    log.debug('Gantt chart rendered successfully with VChart');
+    log.debug('Gantt chart rendered successfully with VTable');
   } catch (error) {
-    log.error('Failed to render gantt chart with VChart:', error);
+    log.error('Failed to render gantt chart with VTable:', error);
     throw error;
   } finally {
     renderer.dispose();
   }
 };
 
-export { drawWithVChart };
+export { drawWithVTable };

--- a/packages/mermaid/src/diagrams/pie/pieRenderer.ts
+++ b/packages/mermaid/src/diagrams/pie/pieRenderer.ts
@@ -181,4 +181,27 @@ export const draw: DrawDefinition = (text, id, _version, diagObj) => {
   configureSvgSize(svg, height, totalWidth, pieConfig.useMaxWidth);
 };
 
-export const renderer = { draw };
+// 导入VChart渲染器
+import { drawWithVChart } from './pieVChartRenderer.js';
+
+// 条件渲染器
+const conditionalDraw: DrawDefinition = async (text, id, _version, diagObj) => {
+  const db = diagObj.db as PieDB;
+  const config = db.getConfig();
+
+  // 检查是否使用VChart渲染器
+  if (config.renderer === 'vchart') {
+    try {
+      // 检查VChart是否可用
+      await import('@visactor/vchart');
+      return await drawWithVChart(text, id, _version, diagObj);
+    } catch (error) {
+      log.warn('VChart not available, falling back to default renderer:', error);
+    }
+  }
+
+  // 使用默认D3渲染器
+  return draw(text, id, _version, diagObj);
+};
+
+export const renderer = { draw: conditionalDraw };

--- a/packages/mermaid/src/diagrams/pie/pieVChart.spec.ts
+++ b/packages/mermaid/src/diagrams/pie/pieVChart.spec.ts
@@ -1,0 +1,117 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { PieDB } from './pieTypes.js';
+import { drawWithVChart } from './pieVChartRenderer.js';
+
+// Mock VChart
+vi.mock('@visactor/vchart', () => ({
+  VChart: vi.fn().mockImplementation(() => ({
+    renderAsync: vi.fn().mockResolvedValue(undefined),
+    release: vi.fn(),
+  })),
+}));
+
+// Mock DOM methods
+Object.defineProperty(global, 'HTMLElement', {
+  value: vi.fn(),
+});
+
+// Mock SVG selection
+vi.mock('../../rendering-util/selectSvgElement.js', () => ({
+  selectSvgElement: vi.fn().mockReturnValue({
+    append: vi.fn().mockReturnValue({
+      attr: vi.fn().mockReturnThis(),
+      style: vi.fn().mockReturnThis(),
+      node: vi.fn().mockReturnValue(document.createElement('div')),
+      append: vi.fn().mockReturnValue({
+        attr: vi.fn().mockReturnThis(),
+        style: vi.fn().mockReturnThis(),
+        node: vi.fn().mockReturnValue(document.createElement('div')),
+      }),
+    }),
+    attr: vi.fn().mockReturnThis(),
+  }),
+}));
+
+// Mock setupGraphViewbox
+vi.mock('../../setupGraphViewbox.js', () => ({
+  configureSvgSize: vi.fn(),
+  setupGraphViewbox: vi.fn(),
+}));
+
+describe('Pie Chart VChart Renderer', () => {
+  let mockDb: PieDB;
+  let mockDiagObj: any;
+
+  beforeEach(() => {
+    mockDb = {
+      getConfig: vi.fn().mockReturnValue({
+        renderer: 'vchart',
+        textPosition: 0.75,
+        useMaxWidth: true,
+      }),
+      getSections: vi.fn().mockReturnValue(
+        new Map([
+          ['Section A', 30],
+          ['Section B', 20],
+          ['Section C', 50],
+        ])
+      ),
+      getDiagramTitle: vi.fn().mockReturnValue('Test Pie Chart'),
+      getShowData: vi.fn().mockReturnValue(true),
+      clear: vi.fn(),
+      setDiagramTitle: vi.fn(),
+      setAccTitle: vi.fn(),
+      getAccTitle: vi.fn(),
+      setAccDescription: vi.fn(),
+      getAccDescription: vi.fn(),
+      addSection: vi.fn(),
+      setShowData: vi.fn(),
+    };
+
+    mockDiagObj = {
+      db: mockDb,
+      globalConfig: {
+        themeVariables: {
+          pie1: '#ff6b6b',
+          pie2: '#4ecdc4',
+          pie3: '#45b7d1',
+          fontFamily: 'Arial, sans-serif',
+          pieTitleTextColor: '#333',
+          pieTitleTextSize: '16px',
+        },
+      },
+    };
+  });
+
+  it('should render pie chart with VChart', async () => {
+    const text = 'pie title Test Chart\n"A" : 30\n"B" : 20\n"C" : 50';
+    const id = 'test-pie';
+    const version = '1.0.0';
+
+    await expect(drawWithVChart(text, id, version, mockDiagObj)).resolves.toBeUndefined();
+
+    expect(mockDb.getSections).toHaveBeenCalled();
+    expect(mockDb.getDiagramTitle).toHaveBeenCalled();
+  });
+
+  it('should extract data correctly', () => {
+    const sections = mockDb.getSections();
+    const data = [...sections.entries()].map(([label, value]) => ({
+      label,
+      value,
+    }));
+
+    expect(data).toEqual([
+      { label: 'Section A', value: 30 },
+      { label: 'Section B', value: 20 },
+      { label: 'Section C', value: 50 },
+    ]);
+  });
+
+  it('should apply theme correctly', () => {
+    // This would test the theme application logic
+    // For now, we just verify the structure
+    expect(mockDiagObj.globalConfig.themeVariables).toBeDefined();
+    expect(mockDiagObj.globalConfig.themeVariables.pie1).toBe('#ff6b6b');
+  });
+});

--- a/packages/mermaid/src/diagrams/pie/pieVChartRenderer.ts
+++ b/packages/mermaid/src/diagrams/pie/pieVChartRenderer.ts
@@ -1,0 +1,205 @@
+import type { PieDiagramConfig } from '../../config.type.js';
+import { getConfig } from '../../diagram-api/diagramAPI.js';
+import type { DrawDefinition } from '../../diagram-api/types.js';
+import { log } from '../../logger.js';
+import { cleanAndMerge } from '../../utils.js';
+import { VChartRenderer } from '../../rendering-util/VChartRenderer.js';
+import type { PieDB, Sections, D3Section } from './pieTypes.js';
+
+/**
+ * 饼图的VChart渲染器实现
+ */
+class PieVChartRenderer extends VChartRenderer {
+  /**
+   * 从数据库提取饼图数据
+   */
+  protected extractData(db: PieDB): D3Section[] {
+    const sections: Sections = db.getSections();
+    return [...sections.entries()].map(([label, value]) => ({
+      label,
+      value,
+    }));
+  }
+
+  /**
+   * 创建VChart饼图规格
+   */
+  protected createVChartSpec(data: D3Section[], _config: Required<PieDiagramConfig>): any {
+    return {
+      type: 'pie',
+      data: [
+        {
+          id: 'pieData',
+          values: data,
+        },
+      ],
+      outerRadius: 0.8,
+      innerRadius: 0,
+      padAngle: 0,
+      categoryField: 'label',
+      valueField: 'value',
+      seriesField: 'label',
+      pie: {
+        style: {
+          stroke: '#fff',
+          strokeWidth: 2,
+        },
+      },
+      label: {
+        visible: true,
+        position: 'outside',
+        style: {
+          fontWeight: 'normal',
+        },
+        formatMethod: (text: string, datum: any) => {
+          const total = data.reduce((sum, item) => sum + item.value, 0);
+          const percentage = ((datum.value / total) * 100).toFixed(0);
+          return `${percentage}%`;
+        },
+      },
+      tooltip: {
+        mark: {
+          content: [
+            {
+              key: (datum: any) => datum.label,
+              value: (datum: any) => datum.value,
+            },
+          ],
+        },
+      },
+      legends: {
+        visible: true,
+        orient: 'right',
+        position: 'middle',
+        item: {
+          shape: {
+            style: {
+              symbolType: 'rect',
+            },
+          },
+        },
+      },
+      animation: {
+        appear: {
+          duration: 1000,
+          easing: 'bounceOut',
+        },
+        enter: {
+          type: 'growAngleIn',
+        },
+      },
+    };
+  }
+
+  /**
+   * 应用mermaid主题到VChart
+   */
+  protected applyTheme(spec: any, themeVariables: any): any {
+    if (!themeVariables) {
+      return spec;
+    }
+
+    // 应用颜色主题
+    const colorScheme = [
+      themeVariables.pie1,
+      themeVariables.pie2,
+      themeVariables.pie3,
+      themeVariables.pie4,
+      themeVariables.pie5,
+      themeVariables.pie6,
+      themeVariables.pie7,
+      themeVariables.pie8,
+      themeVariables.pie9,
+      themeVariables.pie10,
+      themeVariables.pie11,
+      themeVariables.pie12,
+    ].filter(Boolean);
+
+    if (colorScheme.length > 0) {
+      spec.color = colorScheme;
+    }
+
+    // 应用字体配置
+    if (themeVariables.fontFamily) {
+      spec.label = {
+        ...spec.label,
+        style: {
+          ...spec.label?.style,
+          fontFamily: themeVariables.fontFamily,
+        },
+      };
+
+      spec.legends = {
+        ...spec.legends,
+        item: {
+          ...spec.legends?.item,
+          label: {
+            style: {
+              fontFamily: themeVariables.fontFamily,
+            },
+          },
+        },
+      };
+    }
+
+    // 应用标题样式
+    if (themeVariables.pieTitleTextColor || themeVariables.pieTitleTextSize) {
+      spec.title = {
+        visible: true,
+        style: {
+          fill: themeVariables.pieTitleTextColor,
+          fontSize: themeVariables.pieTitleTextSize,
+          fontFamily: themeVariables.fontFamily,
+        },
+      };
+    }
+
+    return spec;
+  }
+}
+
+/**
+ * VChart饼图绘制函数
+ */
+const drawWithVChart: DrawDefinition = async (text, id, _version, diagObj) => {
+  log.debug('rendering pie chart with VChart\n' + text);
+
+  const db = diagObj.db as PieDB;
+  const globalConfig = getConfig();
+  const _pieConfig: Required<PieDiagramConfig> = cleanAndMerge(db.getConfig(), globalConfig.pie);
+
+  const renderer = new PieVChartRenderer();
+
+  try {
+    // 设置图表尺寸
+    const width = 600;
+    const height = 450;
+
+    // 直接调用渲染方法
+    await renderer.render(
+      text,
+      id,
+      _version,
+      {
+        ...diagObj,
+        globalConfig,
+      },
+      width,
+      height
+    );
+
+    // 添加标题
+    const title = db.getDiagramTitle();
+    if (title) {
+      // 标题将通过VChart的title配置显示
+      log.debug(`Pie chart title: ${title}`);
+    }
+  } catch (error) {
+    log.error('Failed to render pie chart with VChart:', error);
+    throw error;
+  } finally {
+    renderer.dispose();
+  }
+};
+
+export { drawWithVChart };

--- a/packages/mermaid/src/diagrams/sankey/sankeyDiagram.ts
+++ b/packages/mermaid/src/diagrams/sankey/sankeyDiagram.ts
@@ -2,7 +2,7 @@ import type { DiagramDefinition } from '../../diagram-api/types.js';
 // @ts-ignore: jison doesn't export types
 import parser from './parser/sankey.jison';
 import db from './sankeyDB.js';
-import renderer from './sankeyRenderer.js';
+import { renderer } from './sankeyRenderer.js';
 import { prepareTextForParsing } from './sankeyUtils.js';
 import sankeyStyles from './styles.js';
 

--- a/packages/mermaid/src/diagrams/sankey/sankeyRenderer.ts
+++ b/packages/mermaid/src/diagrams/sankey/sankeyRenderer.ts
@@ -30,7 +30,7 @@ const alignmentsMap: Record<
 };
 
 /**
- * Draws Sankey diagram.
+ * Default Sankey diagram renderer using D3.
  *
  * @param text - The text of the diagram
  * @param id - The id of the diagram which will be used as a DOM element id¨
@@ -203,6 +203,31 @@ export const draw = function (text: string, id: string, _version: string, diagOb
   setupGraphViewbox(undefined, svg, 0, useMaxWidth);
 };
 
-export default {
-  draw,
+// 条件渲染器
+const conditionalDraw = async (
+  text: string,
+  id: string,
+  _version: string,
+  diagObj: Diagram
+): Promise<void> => {
+  const { sankey: conf } = getConfig();
+  const defaultSankeyConfig = defaultConfig.sankey!;
+
+  // 检查是否使用VChart渲染器
+  const renderer = conf?.renderer ?? defaultSankeyConfig.renderer!;
+  if (renderer === 'vchart') {
+    try {
+      // 检查VChart是否可用
+      await import('@visactor/vchart');
+      const { drawWithVChart } = await import('./sankeyVChartRenderer.js');
+      return await drawWithVChart(text, id, _version, diagObj);
+    } catch (_error) {
+      // VChart not available, fall back to default renderer
+    }
+  }
+
+  // 使用默认D3渲染器
+  return draw(text, id, _version, diagObj);
 };
+
+export const renderer = { draw: conditionalDraw };

--- a/packages/mermaid/src/diagrams/sankey/sankeyVChart.spec.ts
+++ b/packages/mermaid/src/diagrams/sankey/sankeyVChart.spec.ts
@@ -1,0 +1,141 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { Diagram } from '../../Diagram.js';
+import { drawWithVChart } from './sankeyVChartRenderer.js';
+
+// Mock VChart
+vi.mock('@visactor/vchart', () => ({
+  VChart: vi.fn().mockImplementation(() => ({
+    renderAsync: vi.fn().mockResolvedValue(undefined),
+    release: vi.fn(),
+  })),
+}));
+
+// Mock DOM methods
+Object.defineProperty(global, 'HTMLElement', {
+  value: vi.fn(),
+});
+
+// Mock getConfig
+vi.mock('../../diagram-api/diagramAPI.js', () => ({
+  getConfig: vi.fn(() => ({
+    theme: 'default',
+    themeVariables: {
+      primaryColor: '#ff6b6b',
+      primaryTextColor: '#333333',
+      primaryBorderColor: '#ff6b6b',
+      lineColor: '#333333',
+      secondaryColor: '#4ecdc4',
+      tertiaryColor: '#45b7d1',
+      background: '#ffffff',
+      secondaryBorderColor: '#4ecdc4',
+      tertiaryBorderColor: '#45b7d1',
+    },
+  })),
+}));
+
+// Mock document
+Object.defineProperty(global, 'document', {
+  value: {
+    getElementById: vi.fn(() => ({
+      style: {},
+      querySelector: vi.fn(),
+      appendChild: vi.fn(),
+      setAttribute: vi.fn(),
+      getAttribute: vi.fn(),
+      getBoundingClientRect: vi.fn(() => ({ width: 800, height: 600 })),
+    })),
+    querySelector: vi.fn(() => ({
+      style: {},
+      appendChild: vi.fn(),
+      setAttribute: vi.fn(),
+      getAttribute: vi.fn(),
+      getBoundingClientRect: vi.fn(() => ({ width: 800, height: 600 })),
+    })),
+    createElement: vi.fn(() => ({
+      style: {},
+      appendChild: vi.fn(),
+      setAttribute: vi.fn(),
+      getAttribute: vi.fn(),
+    })),
+  },
+  writable: true,
+});
+
+describe('Sankey VChart Renderer', () => {
+  let mockDB: any;
+  let mockDiagObj: Diagram;
+
+  beforeEach(() => {
+    mockDB = {
+      getGraph: vi.fn(() => ({
+        nodes: [{ id: 'A' }, { id: 'B' }, { id: 'C' }],
+        links: [
+          { source: 'A', target: 'B', value: 10 },
+          { source: 'B', target: 'C', value: 5 },
+        ],
+      })),
+      getConfig: vi.fn(() => ({})),
+    };
+
+    mockDiagObj = {
+      db: mockDB,
+    } as unknown as Diagram;
+
+    vi.clearAllMocks();
+  });
+
+  it('should render sankey chart with VChart', async () => {
+    await expect(
+      drawWithVChart('sankey chart', 'test-id', '1.0.0', mockDiagObj)
+    ).resolves.toBeUndefined();
+
+    expect(mockDB.getGraph).toHaveBeenCalled();
+  });
+
+  it('should extract sankey data correctly', () => {
+    const graph = mockDB.getGraph();
+
+    expect(graph.nodes).toEqual([{ id: 'A' }, { id: 'B' }, { id: 'C' }]);
+
+    expect(graph.links).toEqual([
+      { source: 'A', target: 'B', value: 10 },
+      { source: 'B', target: 'C', value: 5 },
+    ]);
+  });
+
+  it('should handle empty data gracefully', async () => {
+    mockDB.getGraph.mockReturnValue({
+      nodes: [],
+      links: [],
+    });
+
+    await expect(
+      drawWithVChart('sankey chart', 'test-id', '1.0.0', mockDiagObj)
+    ).resolves.toBeUndefined();
+
+    expect(mockDB.getGraph).toHaveBeenCalled();
+  });
+
+  it('should transform nodes data correctly', () => {
+    const graph = mockDB.getGraph();
+    const transformedNodes = graph.nodes.map((node: any) => ({ name: node.id }));
+
+    expect(transformedNodes).toEqual([{ name: 'A' }, { name: 'B' }, { name: 'C' }]);
+  });
+
+  it('should pass links data unchanged', () => {
+    const graph = mockDB.getGraph();
+
+    expect(graph.links).toEqual([
+      { source: 'A', target: 'B', value: 10 },
+      { source: 'B', target: 'C', value: 5 },
+    ]);
+  });
+
+  it('should call database methods', async () => {
+    await drawWithVChart('sankey chart', 'test-id', '1.0.0', mockDiagObj);
+
+    expect(mockDB.getGraph).toHaveBeenCalled();
+    expect(mockDB.getConfig).toHaveBeenCalled();
+  });
+});

--- a/packages/mermaid/src/diagrams/sankey/sankeyVChartRenderer.ts
+++ b/packages/mermaid/src/diagrams/sankey/sankeyVChartRenderer.ts
@@ -1,0 +1,170 @@
+import type { Diagram } from '../../Diagram.js';
+import { VChartRenderer } from '../../rendering-util/VChartRenderer.js';
+import { log } from '../../logger.js';
+
+/**
+ * Sankey VChart渲染器类
+ * 继承自VChartRenderer基类，实现桑基图的VChart渲染
+ */
+class SankeyVChartRenderer extends VChartRenderer {
+  /**
+   * 提取数据
+   * 从数据库中提取桑基图数据
+   */
+  protected extractData(db: any): any {
+    return db.getGraph();
+  }
+
+  /**
+   * 创建VChart规范配置
+   * 将mermaid桑基图数据转换为VChart桑基图规范
+   */
+  protected createVChartSpec(data: any, config: any): any {
+    log.debug('Creating VChart spec for sankey chart', { data, config });
+
+    // 转换数据格式为VChart期望的格式
+    const chartData = this.transformData(data);
+
+    // 应用主题配置
+    const colorScheme = this.applyTheme();
+
+    // 创建VChart桑基图规范
+    const spec = {
+      type: 'sankey',
+      data: [
+        {
+          values: [chartData],
+        },
+      ],
+      categoryField: 'id',
+      valueField: 'value',
+      sourceField: 'source',
+      targetField: 'target',
+      nodeKey: 'id',
+
+      // 节点配置
+      nodeAlign: config?.nodeAlignment ?? 'justify',
+      nodeGap: 8,
+      nodeWidth: config?.nodeWidth ?? 10,
+      minNodeHeight: 4,
+
+      // 标签配置
+      label: {
+        visible: config?.showValues !== false,
+        style: {
+          fontSize: 12,
+          fill: '#333',
+          fontFamily: 'Arial, sans-serif',
+        },
+      },
+
+      // 节点样式
+      node: {
+        style: {
+          fill: (datum: any, index: number) => colorScheme[index % colorScheme.length],
+          stroke: '#fff',
+          lineWidth: 1,
+        },
+        state: {
+          hover: {
+            stroke: '#333',
+            lineWidth: 2,
+          },
+        },
+      },
+
+      // 链接样式
+      link: {
+        style: {
+          fillOpacity: 0.6,
+        },
+        state: {
+          hover: {
+            fillOpacity: 0.8,
+          },
+        },
+      },
+
+      // 交互效果
+      emphasis: {
+        enable: true,
+        effect: 'adjacency',
+      },
+    };
+
+    log.debug('Generated VChart spec:', spec);
+    return spec;
+  }
+
+  /**
+   * 转换数据格式
+   * 将mermaid桑基图数据转换为VChart格式
+   */
+  private transformData(graph: any): any {
+    log.debug('Transforming sankey data:', graph);
+
+    // 确保节点有唯一ID
+    const nodes = graph.nodes.map((node: any, index: number) => ({
+      id: node.id ?? `node-${index}`,
+      nodeName: node.id ?? `Node ${index}`,
+    }));
+
+    // 确保链接有正确的source和target引用
+    const links = graph.links.map((link: any) => ({
+      source: link.source,
+      target: link.target,
+      value: link.value ?? 1,
+    }));
+
+    const transformedData = {
+      nodes,
+      links,
+    };
+
+    log.debug('Transformed data:', transformedData);
+    return transformedData;
+  }
+
+  /**
+   * 应用主题配置
+   * 生成VChart颜色方案
+   */
+  protected applyTheme(): string[] {
+    log.debug('Applying theme to sankey chart');
+
+    // 使用默认色彩方案
+    const colors = [
+      '#ff6b6b',
+      '#4ecdc4',
+      '#45b7d1',
+      '#96ceb4',
+      '#feca57',
+      '#ff9ff3',
+      '#54a0ff',
+      '#5f27cd',
+      '#00d2d3',
+      '#ff9f43',
+      '#10ac84',
+      '#ee5253',
+    ];
+
+    log.debug('Generated color scheme:', colors);
+    return colors;
+  }
+}
+
+/**
+ * 使用VChart渲染桑基图
+ * 这是对外暴露的渲染函数
+ */
+export async function drawWithVChart(
+  text: string,
+  id: string,
+  version: string,
+  diagObj: Diagram
+): Promise<void> {
+  log.debug('Drawing sankey chart with VChart', { text, id, version });
+
+  const renderer = new SankeyVChartRenderer();
+  await renderer.render(text, id, version, diagObj, 800, 600);
+}

--- a/packages/mermaid/src/diagrams/xychart/chartBuilder/interfaces.ts
+++ b/packages/mermaid/src/diagrams/xychart/chartBuilder/interfaces.ts
@@ -98,6 +98,7 @@ export interface XYChartConfig {
   yAxis: XYChartAxisConfig;
   chartOrientation: 'vertical' | 'horizontal';
   plotReservedSpacePercent: number;
+  renderer?: 'default' | 'vchart';
 }
 
 export interface XYChartData {

--- a/packages/mermaid/src/diagrams/xychart/xychartDiagram.ts
+++ b/packages/mermaid/src/diagrams/xychart/xychartDiagram.ts
@@ -2,7 +2,7 @@ import type { DiagramDefinition } from '../../diagram-api/types.js';
 // @ts-ignore: Jison doesn't support types.
 import parser from './parser/xychart.jison';
 import db from './xychartDb.js';
-import renderer from './xychartRenderer.js';
+import { renderer } from './xychartRenderer.js';
 
 export const diagram: DiagramDefinition = {
   parser,

--- a/packages/mermaid/src/diagrams/xychart/xychartRenderer.ts
+++ b/packages/mermaid/src/diagrams/xychart/xychartRenderer.ts
@@ -236,6 +236,32 @@ export const draw = (txt: string, id: string, _version: string, diagObj: Diagram
   }
 };
 
-export default {
-  draw,
+// 导入VChart渲染器
+import { drawWithVChart } from './xychartVChartRenderer.js';
+
+// 条件渲染器
+const conditionalDraw = async (
+  text: string,
+  id: string,
+  _version: string,
+  diagObj: Diagram
+): Promise<void> => {
+  const db = diagObj.db as typeof XYChartDB;
+  const config = db.getChartConfig();
+
+  // 检查是否使用VChart渲染器
+  if (config.renderer === 'vchart') {
+    try {
+      // 检查VChart是否可用
+      await import('@visactor/vchart');
+      return await drawWithVChart(text, id, _version, diagObj);
+    } catch (_error) {
+      // VChart not available, fall back to default renderer
+    }
+  }
+
+  // 使用默认渲染器
+  return draw(text, id, _version, diagObj);
 };
+
+export const renderer = { draw: conditionalDraw };

--- a/packages/mermaid/src/diagrams/xychart/xychartVChart.spec.ts
+++ b/packages/mermaid/src/diagrams/xychart/xychartVChart.spec.ts
@@ -285,7 +285,45 @@ describe('XYChart VChart Renderer', () => {
   });
 
   it('should render combination chart with VChart', async () => {
-    // Use default mock data with both bar and line plots
+    // Mock data for combination chart with both bar and line plots
+    mockXYChartDB.getXYChartData.mockReturnValue({
+      title: 'Combination Chart Test',
+      xAxis: {
+        type: 'band',
+        title: 'X Axis',
+        categories: ['A', 'B', 'C', 'D'],
+      },
+      yAxis: {
+        type: 'linear',
+        title: 'Y Axis',
+        min: 0,
+        max: 100,
+      },
+      plots: [
+        {
+          type: 'bar',
+          fill: '#1f77b4',
+          data: [
+            ['A', 10],
+            ['B', 20],
+            ['C', 30],
+            ['D', 40],
+          ],
+        },
+        {
+          type: 'line',
+          strokeFill: '#ff7f0e',
+          strokeWidth: 2,
+          data: [
+            ['A', 15],
+            ['B', 25],
+            ['C', 35],
+            ['D', 45],
+          ],
+        },
+      ],
+    });
+
     await drawWithVChart('test text', 'test-id', '1.0.0', mockDiagram);
 
     expect(mockVChart.renderAsync).toHaveBeenCalled();

--- a/packages/mermaid/src/diagrams/xychart/xychartVChart.spec.ts
+++ b/packages/mermaid/src/diagrams/xychart/xychartVChart.spec.ts
@@ -1,0 +1,445 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { drawWithVChart } from './xychartVChartRenderer.js';
+import type { Diagram } from '../../Diagram.js';
+
+// Mock VChart
+const mockVChart = {
+  renderTo: vi.fn(),
+  renderAsync: vi.fn().mockResolvedValue(undefined),
+  updateSpec: vi.fn(),
+  release: vi.fn(),
+};
+
+vi.mock('@visactor/vchart', () => ({
+  VChart: vi.fn(() => mockVChart),
+  registerTheme: vi.fn(),
+}));
+
+// Mock selectSvgElement
+vi.mock('../../rendering-util/selectSvgElement.js', () => ({
+  selectSvgElement: vi.fn(() => ({
+    node: () => ({
+      appendChild: vi.fn(),
+      setAttribute: vi.fn(),
+    }),
+    attr: vi.fn().mockReturnThis(),
+    append: vi.fn(() => ({
+      attr: vi.fn().mockReturnThis(),
+      style: vi.fn().mockReturnThis(),
+      append: vi.fn(() => ({
+        attr: vi.fn().mockReturnThis(),
+        style: vi.fn().mockReturnThis(),
+        node: () => document.createElement('div'),
+      })),
+      node: () => document.createElement('div'),
+    })),
+    selectAll: vi.fn().mockReturnThis(),
+    remove: vi.fn().mockReturnThis(),
+  })),
+}));
+
+// Mock configureSvgSize
+vi.mock('../../setupGraphViewbox.js', () => ({
+  configureSvgSize: vi.fn(),
+}));
+
+// Mock logger
+vi.mock('../../logger.js', () => ({
+  log: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock XYChartDB
+const mockXYChartDB = {
+  getConfig: vi.fn(() => ({
+    renderer: 'vchart',
+    width: 700,
+    height: 500,
+    titleFontSize: 20,
+    titlePadding: 10,
+    showTitle: true,
+    showDataLabel: false,
+    chartOrientation: 'vertical',
+    plotReservedSpacePercent: 50,
+    xAxis: {
+      showLabel: true,
+      labelFontSize: 14,
+      labelPadding: 5,
+      showTitle: true,
+      titleFontSize: 16,
+      titlePadding: 5,
+      showTick: true,
+      tickLength: 5,
+      tickWidth: 2,
+      showAxisLine: true,
+      axisLineWidth: 2,
+    },
+    yAxis: {
+      showLabel: true,
+      labelFontSize: 14,
+      labelPadding: 5,
+      showTitle: true,
+      titleFontSize: 16,
+      titlePadding: 5,
+      showTick: true,
+      tickLength: 5,
+      tickWidth: 2,
+      showAxisLine: true,
+      axisLineWidth: 2,
+    },
+  })),
+  getChartThemeConfig: vi.fn(() => ({
+    backgroundColor: '#ffffff',
+    titleColor: '#000000',
+    xAxisLabelColor: '#666666',
+    xAxisTitleColor: '#000000',
+    xAxisTickColor: '#cccccc',
+    xAxisLineColor: '#cccccc',
+    yAxisLabelColor: '#666666',
+    yAxisTitleColor: '#000000',
+    yAxisTickColor: '#cccccc',
+    yAxisLineColor: '#cccccc',
+    plotColorPalette: '#1f77b4,#ff7f0e,#2ca02c,#d62728',
+  })),
+  getChartConfig: vi.fn(() => ({
+    width: 700,
+    height: 500,
+    titleFontSize: 20,
+    titlePadding: 10,
+    showTitle: true,
+    showDataLabel: false,
+    chartOrientation: 'vertical',
+    plotReservedSpacePercent: 50,
+    renderer: 'vchart',
+    xAxis: {
+      showLabel: true,
+      labelFontSize: 14,
+      labelPadding: 5,
+      showTitle: true,
+      titleFontSize: 16,
+      titlePadding: 5,
+      showTick: true,
+      tickLength: 5,
+      tickWidth: 2,
+      showAxisLine: true,
+      axisLineWidth: 2,
+    },
+    yAxis: {
+      showLabel: true,
+      labelFontSize: 14,
+      labelPadding: 5,
+      showTitle: true,
+      titleFontSize: 16,
+      titlePadding: 5,
+      showTick: true,
+      tickLength: 5,
+      tickWidth: 2,
+      showAxisLine: true,
+      axisLineWidth: 2,
+    },
+  })),
+  getXYChartData: vi.fn(() => ({
+    title: 'Test XY Chart',
+    xAxis: {
+      type: 'band',
+      title: 'X Axis',
+      categories: ['A', 'B', 'C', 'D'],
+    },
+    yAxis: {
+      type: 'linear',
+      title: 'Y Axis',
+      min: 0,
+      max: 100,
+    },
+    plots: [
+      {
+        type: 'bar',
+        fill: '#1f77b4',
+        data: [
+          ['A', 10],
+          ['B', 20],
+          ['C', 30],
+          ['D', 40],
+        ],
+      },
+      {
+        type: 'line',
+        strokeFill: '#ff7f0e',
+        strokeWidth: 2,
+        data: [
+          ['A', 15],
+          ['B', 25],
+          ['C', 35],
+          ['D', 45],
+        ],
+      },
+    ],
+  })),
+};
+
+describe('XYChart VChart Renderer', () => {
+  let mockDiagram: Diagram;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDiagram = {
+      db: mockXYChartDB,
+    } as unknown as Diagram;
+  });
+
+  it('should render bar chart with VChart', async () => {
+    // Mock data for bar chart only
+    mockXYChartDB.getXYChartData.mockReturnValue({
+      title: 'Bar Chart Test',
+      xAxis: {
+        type: 'band',
+        title: 'Categories',
+        categories: ['A', 'B', 'C'],
+      },
+      yAxis: {
+        type: 'linear',
+        title: 'Values',
+        min: 0,
+        max: 50,
+      },
+      plots: [
+        {
+          type: 'bar',
+          fill: '#1f77b4',
+          data: [
+            ['A', 10],
+            ['B', 30],
+            ['C', 20],
+          ],
+        },
+      ],
+    });
+
+    await drawWithVChart('test text', 'test-id', '1.0.0', mockDiagram);
+
+    expect(mockVChart.renderAsync).toHaveBeenCalled();
+
+    // Get the VChart constructor call to check the spec
+    const { VChart } = await import('@visactor/vchart');
+    const vchartCalls = (VChart as any).mock.calls;
+    expect(vchartCalls.length).toBeGreaterThan(0);
+
+    const spec = vchartCalls[0][0];
+    expect(spec.type).toBe('bar');
+    expect(spec.data).toBeDefined();
+    expect(spec.data[0].values).toEqual([
+      { category: 'A', value: 10 },
+      { category: 'B', value: 30 },
+      { category: 'C', value: 20 },
+    ]);
+  });
+
+  it('should render line chart with VChart', async () => {
+    // Mock data for line chart only
+    mockXYChartDB.getXYChartData.mockReturnValue({
+      title: 'Line Chart Test',
+      xAxis: {
+        type: 'band',
+        title: 'Time',
+        categories: ['Jan', 'Feb', 'Mar'],
+      },
+      yAxis: {
+        type: 'linear',
+        title: 'Temperature',
+        min: 0,
+        max: 30,
+      },
+      plots: [
+        {
+          type: 'line',
+          strokeFill: '#ff7f0e',
+          strokeWidth: 2,
+          data: [
+            ['Jan', 5],
+            ['Feb', 15],
+            ['Mar', 25],
+          ],
+        },
+      ],
+    });
+
+    await drawWithVChart('test text', 'test-id', '1.0.0', mockDiagram);
+
+    expect(mockVChart.renderAsync).toHaveBeenCalled();
+
+    // Check the VChart spec for line chart
+    const { VChart } = await import('@visactor/vchart');
+    const vchartCalls = (VChart as any).mock.calls;
+    const spec = vchartCalls[0][0];
+
+    expect(spec.type).toBe('line');
+    expect(spec.data[0].values).toEqual([
+      { category: 'Jan', value: 5 },
+      { category: 'Feb', value: 15 },
+      { category: 'Mar', value: 25 },
+    ]);
+  });
+
+  it('should render combination chart with VChart', async () => {
+    // Use default mock data with both bar and line plots
+    await drawWithVChart('test text', 'test-id', '1.0.0', mockDiagram);
+
+    expect(mockVChart.renderAsync).toHaveBeenCalled();
+
+    // Check the VChart spec for combination chart
+    const { VChart } = await import('@visactor/vchart');
+    const vchartCalls = (VChart as any).mock.calls;
+    const spec = vchartCalls[0][0];
+
+    expect(spec.type).toBe('common');
+    expect(spec.series).toHaveLength(2);
+    expect(spec.series[0].type).toBe('bar');
+    expect(spec.series[1].type).toBe('line');
+  });
+
+  it('should apply theme colors correctly', async () => {
+    mockXYChartDB.getChartThemeConfig.mockReturnValue({
+      backgroundColor: '#f5f5f5',
+      titleColor: '#333333',
+      xAxisLabelColor: '#555555',
+      xAxisTitleColor: '#333333',
+      xAxisTickColor: '#cccccc',
+      xAxisLineColor: '#cccccc',
+      yAxisLabelColor: '#555555',
+      yAxisTitleColor: '#333333',
+      yAxisTickColor: '#cccccc',
+      yAxisLineColor: '#cccccc',
+      plotColorPalette: '#e74c3c,#3498db,#2ecc71',
+    });
+
+    await drawWithVChart('test text', 'test-id', '1.0.0', mockDiagram);
+
+    const { VChart } = await import('@visactor/vchart');
+    const vchartCalls = (VChart as any).mock.calls;
+    const spec = vchartCalls[0][0];
+
+    // Check theme application
+    expect(spec.background).toBe('#f5f5f5');
+    expect(spec.title?.style?.text?.fill).toBe('#333333');
+  });
+
+  it('should handle linear x-axis', async () => {
+    // Mock data with linear x-axis
+    mockXYChartDB.getXYChartData.mockReturnValue({
+      title: 'Linear X-Axis Test',
+      xAxis: {
+        type: 'linear',
+        title: 'Time (hours)',
+        min: 0,
+        max: 24,
+      } as any,
+      yAxis: {
+        type: 'linear',
+        title: 'Temperature',
+        min: 0,
+        max: 30,
+      },
+      plots: [
+        {
+          type: 'line',
+          strokeFill: '#ff7f0e',
+          strokeWidth: 2,
+          data: [
+            ['0', 10],
+            ['6', 15],
+            ['12', 25],
+            ['18', 20],
+            ['24', 12],
+          ],
+        },
+      ],
+    });
+
+    await drawWithVChart('test text', 'test-id', '1.0.0', mockDiagram);
+
+    const { VChart } = await import('@visactor/vchart');
+    const vchartCalls = (VChart as any).mock.calls;
+    const spec = vchartCalls[0][0];
+
+    // Check linear x-axis configuration
+    expect(spec.axes).toBeDefined();
+    const xAxis = spec.axes.find((axis: any) => axis.orient === 'bottom');
+    expect(xAxis?.type).toBe('linear');
+    expect(xAxis?.min).toBe(0);
+    expect(xAxis?.max).toBe(24);
+  });
+
+  it('should handle horizontal orientation', async () => {
+    mockXYChartDB.getChartConfig.mockReturnValue({
+      ...mockXYChartDB.getChartConfig(),
+      chartOrientation: 'horizontal',
+    });
+
+    await drawWithVChart('test text', 'test-id', '1.0.0', mockDiagram);
+
+    const { VChart } = await import('@visactor/vchart');
+    const vchartCalls = (VChart as any).mock.calls;
+    const spec = vchartCalls[0][0];
+
+    // For horizontal charts, x and y should be swapped
+    const xAxis = spec.axes?.find((axis: any) => axis.orient === 'bottom');
+    const yAxis = spec.axes?.find((axis: any) => axis.orient === 'left');
+
+    // In horizontal orientation, categories should be on y-axis
+    expect(yAxis?.type).toBe('band');
+    expect(xAxis?.type).toBe('linear');
+  });
+
+  it('should configure chart dimensions correctly', async () => {
+    mockXYChartDB.getChartConfig.mockReturnValue({
+      ...mockXYChartDB.getChartConfig(),
+      width: 800,
+      height: 600,
+    });
+
+    await drawWithVChart('test text', 'test-id', '1.0.0', mockDiagram);
+
+    const { VChart } = await import('@visactor/vchart');
+    const vchartCalls = (VChart as any).mock.calls;
+    const spec = vchartCalls[0][0];
+
+    expect(spec.width).toBe(800);
+    expect(spec.height).toBe(600);
+  });
+
+  it('should handle empty data gracefully', async () => {
+    mockXYChartDB.getXYChartData.mockReturnValue({
+      title: 'Empty Chart',
+      xAxis: {
+        type: 'band',
+        title: 'X Axis',
+        categories: [],
+      },
+      yAxis: {
+        type: 'linear',
+        title: 'Y Axis',
+        min: 0,
+        max: 100,
+      },
+      plots: [],
+    });
+
+    await drawWithVChart('test text', 'test-id', '1.0.0', mockDiagram);
+
+    // Should not throw and VChart should still be called
+    expect(mockVChart.renderAsync).toHaveBeenCalled();
+  });
+
+  it('should handle completely undefined data gracefully', async () => {
+    mockXYChartDB.getXYChartData.mockReturnValue(null as any);
+
+    // Should not throw even with undefined data
+    await expect(
+      drawWithVChart('test text', 'test-id', '1.0.0', mockDiagram)
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/mermaid/src/diagrams/xychart/xychartVChartRenderer.ts
+++ b/packages/mermaid/src/diagrams/xychart/xychartVChartRenderer.ts
@@ -11,13 +11,15 @@ class XYChartVChartRenderer extends VChartRenderer {
     const xyChartData = db.getXYChartData();
 
     log.debug('XY Chart data:', xyChartData);
+    log.debug('Plots count:', xyChartData?.plots?.length);
+    log.debug('Plots data:', xyChartData?.plots);
 
     if (!xyChartData?.plots?.length) {
       log.warn('No plot data found for XY chart');
       return {
         data: [],
-        xField: 'x',
-        yField: 'y',
+        xField: 'category',
+        yField: 'value',
         type: 'line',
         chartType: 'line',
         plots: [],
@@ -29,25 +31,28 @@ class XYChartVChartRenderer extends VChartRenderer {
 
     const transformedData: any[] = [];
 
-    // 处理每个层的数据
+    // 处理每个层的数据，转换为VChart期望的格式
     xyChartData.plots.forEach((plot: any, plotIndex: number) => {
       plot.data.forEach((dataPoint: any) => {
         const [xValue, yValue] = dataPoint;
         transformedData.push({
-          x: xValue,
-          y: yValue,
+          category: xValue,
+          value: yValue,
           series: `Series ${plotIndex + 1}`,
           type: plot.type, // 'line' 或 'bar'
         });
       });
     });
 
+    const chartType = this.determineChartType(xyChartData);
+    log.debug('Determined chart type:', chartType);
+
     return {
       data: transformedData,
-      xField: 'x',
-      yField: 'y',
+      xField: 'category',
+      yField: 'value',
       seriesField: 'series',
-      chartType: this.determineChartType(xyChartData),
+      chartType: chartType,
       plots: xyChartData.plots,
       xAxis: xyChartData.xAxis,
       yAxis: xyChartData.yAxis,
@@ -62,12 +67,17 @@ class XYChartVChartRenderer extends VChartRenderer {
     // 如果包含多种类型的图层，使用组合图表
     const plotTypes = new Set(xyChartData.plots.map((plot: any) => plot.type));
 
+    log.debug('Plot types found:', [...plotTypes]);
+    log.debug('Number of plot types:', plotTypes.size);
+
     if (plotTypes.size > 1) {
+      log.debug('Multiple plot types detected, using common chart type');
       return 'common'; // VChart组合图表
     }
 
     // 单一类型图表
     const firstPlotType = xyChartData.plots[0]?.type;
+    log.debug('Single plot type detected:', firstPlotType);
     switch (firstPlotType) {
       case 'line':
         return 'line';
@@ -131,22 +141,30 @@ class XYChartVChartRenderer extends VChartRenderer {
         });
       });
     } else {
+      // 单一类型图表的数据格式
+      const chartData = data.data.map((item: any) => ({
+        category: item.category,
+        value: item.value,
+      }));
+
       spec.data = [
         {
           id: 'data',
-          values: data.data,
+          values: chartData,
         },
       ];
 
       spec.xField = data.xField;
       spec.yField = data.yField;
-      spec.seriesField = data.seriesField;
+      if (data.plots.length > 1) {
+        spec.seriesField = data.seriesField;
+      }
     }
     const isHorizontal = _config.chartOrientation === 'horizontal';
     let xAxisConfig, yAxisConfig;
 
     if (isHorizontal) {
-      //x为数值，y为分类
+      // 水平图表：x为数值轴，y为分类轴
       xAxisConfig = {
         orient: 'bottom',
         type: 'linear',
@@ -159,18 +177,14 @@ class XYChartVChartRenderer extends VChartRenderer {
       };
       yAxisConfig = {
         orient: 'left',
-        type: data.xAxis?.type === 'linear' ? 'linear' : 'band',
+        type: 'band',
         title: {
           visible: !!data.xAxis?.title,
           text: data.xAxis?.title ?? '',
         },
-        ...(data.xAxis?.type === 'linear' && {
-          min: data.xAxis?.min,
-          max: data.xAxis?.max,
-        }),
       };
     } else {
-      // 垂直图表：x为分类，y轴为数值
+      // 垂直图表：x为分类/线性轴，y为数值轴
       xAxisConfig = {
         orient: 'bottom',
         type: data.xAxis?.type === 'linear' ? 'linear' : 'band',
@@ -222,6 +236,7 @@ class XYChartVChartRenderer extends VChartRenderer {
     };
 
     log.debug('VChart spec for XY chart:', spec);
+    log.debug('Final chart type:', spec.type);
     return spec;
   }
 
@@ -237,14 +252,32 @@ class XYChartVChartRenderer extends VChartRenderer {
       themeVariables.secondaryBorderColor || '#feca57',
     ];
 
-    return {
+    const themedSpec = {
       ...spec,
       color: colors,
-      background: themeVariables.background ?? '#ffffff',
       theme: {
         fontFamily: themeVariables.fontFamily ?? 'Arial, sans-serif',
       },
     };
+
+    // 应用背景色
+    if (themeVariables.backgroundColor) {
+      themedSpec.background = themeVariables.backgroundColor;
+    }
+
+    // 应用标题样式
+    if (themedSpec.title && themeVariables.titleColor) {
+      themedSpec.title = {
+        ...themedSpec.title,
+        style: {
+          text: {
+            fill: themeVariables.titleColor,
+          },
+        },
+      };
+    }
+
+    return themedSpec;
   }
 }
 
@@ -257,6 +290,18 @@ export const drawWithVChart: DrawDefinition = async (text, id, _version, diagObj
   const db = diagObj.db as typeof XYChartDB;
   const config = db.getChartConfig();
 
+  // 扩展 diagObj 以包含主题变量和重写getConfig方法
+  const extendedDiagObj = {
+    ...diagObj,
+    globalConfig: {
+      themeVariables: db.getChartThemeConfig(),
+    },
+    db: {
+      ...db,
+      getConfig: () => config, // 确保基类使用正确的配置
+    },
+  };
+
   const renderer = new XYChartVChartRenderer();
-  await renderer.render(text, id, _version, diagObj, config.width, config.height);
+  await renderer.render(text, id, _version, extendedDiagObj, config.width, config.height);
 };

--- a/packages/mermaid/src/diagrams/xychart/xychartVChartRenderer.ts
+++ b/packages/mermaid/src/diagrams/xychart/xychartVChartRenderer.ts
@@ -1,0 +1,262 @@
+import type { DrawDefinition } from '../../diagram-api/types.js';
+import { log } from '../../logger.js';
+import { VChartRenderer } from '../../rendering-util/VChartRenderer.js';
+import type XYChartDB from './xychartDb.js';
+
+/**
+ * XY图表的VChart渲染器实现
+ */
+class XYChartVChartRenderer extends VChartRenderer {
+  protected extractData(db: any): any {
+    const xyChartData = db.getXYChartData();
+
+    log.debug('XY Chart data:', xyChartData);
+
+    if (!xyChartData?.plots?.length) {
+      log.warn('No plot data found for XY chart');
+      return {
+        data: [],
+        xField: 'x',
+        yField: 'y',
+        type: 'line',
+        chartType: 'line',
+        plots: [],
+        xAxis: { type: 'band', title: '', categories: [] },
+        yAxis: { type: 'linear', title: '', min: 0, max: 100 },
+        title: '',
+      };
+    }
+
+    const transformedData: any[] = [];
+
+    // 处理每个层的数据
+    xyChartData.plots.forEach((plot: any, plotIndex: number) => {
+      plot.data.forEach((dataPoint: any) => {
+        const [xValue, yValue] = dataPoint;
+        transformedData.push({
+          x: xValue,
+          y: yValue,
+          series: `Series ${plotIndex + 1}`,
+          type: plot.type, // 'line' 或 'bar'
+        });
+      });
+    });
+
+    return {
+      data: transformedData,
+      xField: 'x',
+      yField: 'y',
+      seriesField: 'series',
+      chartType: this.determineChartType(xyChartData),
+      plots: xyChartData.plots,
+      xAxis: xyChartData.xAxis,
+      yAxis: xyChartData.yAxis,
+      title: xyChartData.title,
+    };
+  }
+
+  /**
+   * 确定图表类型
+   */
+  private determineChartType(xyChartData: any): string {
+    // 如果包含多种类型的图层，使用组合图表
+    const plotTypes = new Set(xyChartData.plots.map((plot: any) => plot.type));
+
+    if (plotTypes.size > 1) {
+      return 'common'; // VChart组合图表
+    }
+
+    // 单一类型图表
+    const firstPlotType = xyChartData.plots[0]?.type;
+    switch (firstPlotType) {
+      case 'line':
+        return 'line';
+      case 'bar':
+        return 'bar';
+      default:
+        return 'line';
+    }
+  }
+
+  /**
+   * 开始创建VChart配置
+   */
+  protected createVChartSpec(data: any, _config: any): any {
+    const colors = [
+      '#ff6b6b',
+      '#4ecdc4',
+      '#45b7d1',
+      '#96ceb4',
+      '#feca57',
+      '#ff9ff3',
+      '#54a0ff',
+      '#5f27cd',
+      '#00d2d3',
+      '#ff9f43',
+    ];
+
+    const spec: any = {
+      type: data.chartType,
+      padding: { top: 20, right: 20, bottom: 40, left: 60 },
+      color: colors,
+    };
+
+    if (data.chartType === 'common') {
+      spec.data = [
+        {
+          id: 'data',
+          values: data.data,
+        },
+      ];
+
+      spec.series = [];
+      const seriesByType = new Map();
+      data.plots.forEach((plot: any, index: number) => {
+        const seriesKey = plot.type;
+        if (!seriesByType.has(seriesKey)) {
+          seriesByType.set(seriesKey, []);
+        }
+        seriesByType.get(seriesKey).push(`Series ${index + 1}`);
+      });
+      seriesByType.forEach((seriesNames, plotType) => {
+        spec.series.push({
+          type: plotType,
+          data: {
+            id: 'data',
+          },
+          xField: data.xField,
+          yField: data.yField,
+          seriesField: data.seriesField,
+          dataFilter: (datum: any) => seriesNames.includes(datum.series),
+        });
+      });
+    } else {
+      spec.data = [
+        {
+          id: 'data',
+          values: data.data,
+        },
+      ];
+
+      spec.xField = data.xField;
+      spec.yField = data.yField;
+      spec.seriesField = data.seriesField;
+    }
+    const isHorizontal = _config.chartOrientation === 'horizontal';
+    let xAxisConfig, yAxisConfig;
+
+    if (isHorizontal) {
+      //x为数值，y为分类
+      xAxisConfig = {
+        orient: 'bottom',
+        type: 'linear',
+        title: {
+          visible: !!data.yAxis?.title,
+          text: data.yAxis?.title ?? '',
+        },
+        min: data.yAxis?.min,
+        max: data.yAxis?.max,
+      };
+      yAxisConfig = {
+        orient: 'left',
+        type: data.xAxis?.type === 'linear' ? 'linear' : 'band',
+        title: {
+          visible: !!data.xAxis?.title,
+          text: data.xAxis?.title ?? '',
+        },
+        ...(data.xAxis?.type === 'linear' && {
+          min: data.xAxis?.min,
+          max: data.xAxis?.max,
+        }),
+      };
+    } else {
+      // 垂直图表：x为分类，y轴为数值
+      xAxisConfig = {
+        orient: 'bottom',
+        type: data.xAxis?.type === 'linear' ? 'linear' : 'band',
+        title: {
+          visible: !!data.xAxis?.title,
+          text: data.xAxis?.title ?? '',
+        },
+        ...(data.xAxis?.type === 'linear' && {
+          min: data.xAxis?.min,
+          max: data.xAxis?.max,
+        }),
+      };
+      yAxisConfig = {
+        orient: 'left',
+        type: 'linear',
+        title: {
+          visible: !!data.yAxis?.title,
+          text: data.yAxis?.title ?? '',
+        },
+        min: data.yAxis?.min,
+        max: data.yAxis?.max,
+      };
+    }
+
+    spec.axes = [xAxisConfig, yAxisConfig];
+
+    // 标题
+    if (data.title) {
+      spec.title = {
+        visible: true,
+        text: data.title,
+        align: 'center',
+      };
+    }
+
+    // 图例
+    spec.legends = [
+      {
+        visible: data.plots.length > 1,
+        orient: 'top',
+        position: 'end',
+      },
+    ];
+
+    // 交互
+    spec.crosshair = {
+      xField: { visible: true },
+      yField: { visible: true },
+    };
+
+    log.debug('VChart spec for XY chart:', spec);
+    return spec;
+  }
+
+  /**
+   * 应用主题到VChart配置
+   */
+  protected applyTheme(spec: any, themeVariables: any): any {
+    const colors = [
+      themeVariables.primaryColor || '#ff6b6b',
+      themeVariables.secondaryColor || '#4ecdc4',
+      themeVariables.tertiaryColor || '#45b7d1',
+      themeVariables.primaryBorderColor || '#96ceb4',
+      themeVariables.secondaryBorderColor || '#feca57',
+    ];
+
+    return {
+      ...spec,
+      color: colors,
+      background: themeVariables.background ?? '#ffffff',
+      theme: {
+        fontFamily: themeVariables.fontFamily ?? 'Arial, sans-serif',
+      },
+    };
+  }
+}
+
+/**
+ * 使用VChart渲染xy图表的函数
+ */
+export const drawWithVChart: DrawDefinition = async (text, id, _version, diagObj) => {
+  log.debug('Rendering XY chart with VChart');
+
+  const db = diagObj.db as typeof XYChartDB;
+  const config = db.getChartConfig();
+
+  const renderer = new XYChartVChartRenderer();
+  await renderer.render(text, id, _version, diagObj, config.width, config.height);
+};

--- a/packages/mermaid/src/rendering-util/VChartRenderer.ts
+++ b/packages/mermaid/src/rendering-util/VChartRenderer.ts
@@ -1,0 +1,190 @@
+import type { VChart } from '@visactor/vchart';
+import type { SVG } from '../diagram-api/types.js';
+import { selectSvgElement } from './selectSvgElement.js';
+import { configureSvgSize } from '../setupGraphViewbox.js';
+import { log } from '../logger.js';
+
+/**
+ * VChart渲染器基类，提供统一的VChart集成接口
+ */
+export abstract class VChartRenderer {
+  protected chart: VChart | null = null;
+  protected container: HTMLElement | null = null;
+
+  /**
+   * 抽象方法：子类需要实现如何转换mermaid数据为VChart规格
+   */
+  protected abstract createVChartSpec(data: any, config: any): any;
+
+  /**
+   * 抽象方法：子类需要实现如何应用主题
+   */
+  protected abstract applyTheme(spec: any, themeVariables: any): any;
+
+  /**
+   * 初始化VChart容器
+   */
+  protected initContainer(id: string): HTMLElement {
+    const svg: SVG = selectSvgElement(id);
+    // 创建一个div容器来承载VChart
+    const foreignObject = svg.append('foreignObject').attr('width', '100%').attr('height', '100%');
+
+    const container = foreignObject
+      .append('xhtml:div')
+      .style('width', '100%')
+      .style('height', '100%')
+      .node() as HTMLElement;
+
+    this.container = container;
+    return container;
+  }
+
+  /**
+   * 渲染VChart图表
+   */
+  protected async renderVChart(
+    spec: any,
+    container: HTMLElement,
+    width: number,
+    height: number
+  ): Promise<VChart> {
+    try {
+      // 动态导入VChart
+      const { VChart } = await import('@visactor/vchart');
+
+      // 设置图表尺寸
+      const chartSpec = {
+        ...spec,
+        width,
+        height,
+      };
+
+      // 创建VChart实例
+      this.chart = new VChart(chartSpec, {
+        dom: container,
+        mode: 'desktop-browser',
+        animation: true,
+      });
+
+      // 渲染图表
+      await this.chart.renderAsync();
+
+      log.debug('VChart rendered successfully');
+      return this.chart;
+    } catch (error) {
+      log.error('Failed to render VChart:', error);
+      throw new Error(`VChart rendering failed: ${String(error)}`);
+    }
+  }
+
+  /**
+   * 清理资源
+   */
+  public dispose(): void {
+    if (this.chart) {
+      this.chart.release();
+      this.chart = null;
+    }
+    this.container = null;
+  }
+
+  /**
+   * 通用的绘制方法模板
+   */
+  public async render(
+    text: string,
+    id: string,
+    _version: string,
+    diagObj: any,
+    width: number,
+    height: number
+  ): Promise<void> {
+    log.debug(`Rendering ${this.constructor.name} with VChart\n${text}`);
+
+    try {
+      // 获取数据和配置
+      const db = diagObj.db;
+      const config = db.getConfig();
+      const data = this.extractData(db);
+
+      // 创建VChart规格
+      let spec = this.createVChartSpec(data, config);
+
+      // 应用主题
+      const { themeVariables } = diagObj.globalConfig ?? {};
+      if (themeVariables) {
+        spec = this.applyTheme(spec, themeVariables);
+      }
+
+      // 初始化容器
+      const container = this.initContainer(id);
+
+      // 渲染图表
+      await this.renderVChart(spec, container, width, height);
+
+      // 配置SVG大小
+      const svg = selectSvgElement(id);
+      configureSvgSize(svg, height, width, config.useMaxWidth);
+    } catch (error) {
+      log.error(`Failed to render ${this.constructor.name}:`, error);
+      // 回退到错误状态或默认渲染器
+      throw error;
+    }
+  }
+
+  /**
+   * 从数据库提取数据的抽象方法
+   */
+  protected abstract extractData(db: any): any;
+}
+
+/**
+ * VChart渲染器工厂，用于根据配置选择渲染器
+ */
+export class VChartRendererFactory {
+  /**
+   * 检查是否应该使用VChart渲染器
+   */
+  static shouldUseVChart(config: any): boolean {
+    return config?.renderer === 'vchart';
+  }
+
+  /**
+   * 检查VChart是否可用
+   */
+  static async isVChartAvailable(): Promise<boolean> {
+    try {
+      await import('@visactor/vchart');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * 创建条件渲染器包装器
+   */
+  static createConditionalRenderer<T extends any[]>(
+    vchartRenderer: (...args: T) => Promise<void>,
+    defaultRenderer: (...args: T) => void,
+    getConfig: (diagObj: any) => any
+  ): (...args: T) => Promise<void> | void {
+    return async (...args: T) => {
+      const diagObj = args[3]; // diagObj是第4个参数
+      const config = getConfig(diagObj);
+
+      if (VChartRendererFactory.shouldUseVChart(config)) {
+        // 检查VChart是否可用
+        const isAvailable = await VChartRendererFactory.isVChartAvailable();
+        if (isAvailable) {
+          return await vchartRenderer(...args);
+        } else {
+          log.warn('VChart not available, falling back to default renderer');
+        }
+      }
+
+      // 使用默认渲染器
+      return defaultRenderer(...args);
+    };
+  }
+}

--- a/packages/mermaid/src/schemas/config.schema.yaml
+++ b/packages/mermaid/src/schemas/config.schema.yaml
@@ -993,6 +993,16 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
     type: object
     unevaluatedProperties: false
     properties:
+      renderer:
+        description: |
+          Decides which rendering engine to use for pie chart rendering.
+          - default: Use the original D3-based pie chart renderer
+          - vchart: Use VChart for enhanced rendering capabilities
+        type: string
+        enum:
+          - default
+          - vchart
+        default: default
       textPosition:
         type: number
         minimum: 0
@@ -1208,6 +1218,16 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
       - chartOrientation
       - plotReservedSpacePercent
     properties:
+      renderer:
+        description: |
+          Decides which rendering engine to use for XY chart rendering.
+          - default: Use the original custom XY chart renderer
+          - vchart: Use VChart for enhanced rendering capabilities
+        type: string
+        enum:
+          - default
+          - vchart
+        default: default
       width:
         description: width of the chart
         type: number
@@ -2163,6 +2183,16 @@ $defs: # JSON Schema definition (maybe we should move these to a separate file)
     type: object
     unevaluatedProperties: false
     properties:
+      renderer:
+        description: |
+          Decides which rendering engine to use for sankey diagram rendering.
+          - default: Use the original D3-sankey based renderer
+          - vchart: Use VChart for enhanced rendering capabilities
+        type: string
+        enum:
+          - default
+          - vchart
+        default: default
       width:
         type: number
         default: 600

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   roughjs:
-    hash: 3543d47108cb41b68ec6a671c0e1f9d0cfe2ce524fea5b0992511ae84c3c6b64
+    hash: vxb6t6fqvzyhwhtjiliqr25jyq
     path: patches/roughjs.patch
 
 importers:
@@ -229,6 +229,9 @@ importers:
       '@types/d3':
         specifier: ^7.4.3
         version: 7.4.3
+      '@visactor/vchart':
+        specifier: ^2.0.2
+        version: 2.0.2
       cytoscape:
         specifier: ^3.29.3
         version: 3.31.0
@@ -267,7 +270,7 @@ importers:
         version: 15.0.7
       roughjs:
         specifier: ^4.6.6
-        version: 4.6.6(patch_hash=3543d47108cb41b68ec6a671c0e1f9d0cfe2ce524fea5b0992511ae84c3c6b64)
+        version: 4.6.6(patch_hash=vxb6t6fqvzyhwhtjiliqr25jyq)
       stylis:
         specifier: ^4.3.6
         version: 4.3.6
@@ -2699,6 +2702,82 @@ packages:
   '@polka/url@1.0.0-next.28':
     resolution: {integrity: sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==}
 
+  '@resvg/resvg-js-android-arm-eabi@2.4.1':
+    resolution: {integrity: sha512-AA6f7hS0FAPpvQMhBCf6f1oD1LdlqNXKCxAAPpKh6tR11kqV0YIB9zOlIYgITM14mq2YooLFl6XIbbvmY+jwUw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@resvg/resvg-js-android-arm64@2.4.1':
+    resolution: {integrity: sha512-/QleoRdPfsEuH9jUjilYcDtKK/BkmWcK+1LXM8L2nsnf/CI8EnFyv7ZzCj4xAIvZGAy9dTYr/5NZBcTwxG2HQg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@resvg/resvg-js-darwin-arm64@2.4.1':
+    resolution: {integrity: sha512-U1oMNhea+kAXgiEXgzo7EbFGCD1Edq5aSlQoe6LMly6UjHzgx2W3N5kEXCwU/CgN5FiQhZr7PlSJSlcr7mdhfg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@resvg/resvg-js-darwin-x64@2.4.1':
+    resolution: {integrity: sha512-avyVh6DpebBfHHtTQTZYSr6NG1Ur6TEilk1+H0n7V+g4F7x7WPOo8zL00ZhQCeRQ5H4f8WXNWIEKL8fwqcOkYw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.4.1':
+    resolution: {integrity: sha512-isY/mdKoBWH4VB5v621co+8l101jxxYjuTkwOLsbW+5RK9EbLciPlCB02M99ThAHzI2MYxIUjXNmNgOW8btXvw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-arm64-gnu@2.4.1':
+    resolution: {integrity: sha512-uY5voSCrFI8TH95vIYBm5blpkOtltLxLRODyhKJhGfskOI7XkRw5/t1u0sWAGYD8rRSNX+CA+np86otKjubrNg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-arm64-musl@2.4.1':
+    resolution: {integrity: sha512-6mT0+JBCsermKMdi/O2mMk3m7SqOjwi9TKAwSngRZ/nQoL3Z0Z5zV+572ztgbWr0GODB422uD8e9R9zzz38dRQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-x64-gnu@2.4.1':
+    resolution: {integrity: sha512-60KnrscLj6VGhkYOJEmmzPlqqfcw1keDh6U+vMcNDjPhV3B5vRSkpP/D/a8sfokyeh4VEacPSYkWGezvzS2/mg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@resvg/resvg-js-linux-x64-musl@2.4.1':
+    resolution: {integrity: sha512-0AMyZSICC1D7ge115cOZQW8Pcad6PjWuZkBFF3FJuSxC6Dgok0MQnLTs2MfMdKBlAcwO9dXsf3bv9tJZj8pATA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@resvg/resvg-js-win32-arm64-msvc@2.4.1':
+    resolution: {integrity: sha512-76XDFOFSa3d0QotmcNyChh2xHwk+JTFiEQBVxMlHpHMeq7hNrQJ1IpE1zcHSQvrckvkdfLboKRrlGB86B10Qjw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@resvg/resvg-js-win32-ia32-msvc@2.4.1':
+    resolution: {integrity: sha512-odyVFGrEWZIzzJ89KdaFtiYWaIJh9hJRW/frcEcG3agJ464VXkN/2oEVF5ulD+5mpGlug9qJg7htzHcKxDN8sg==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@resvg/resvg-js-win32-x64-msvc@2.4.1':
+    resolution: {integrity: sha512-vY4kTLH2S3bP+puU5x7hlAxHv+ulFgcK6Zn3efKSr0M0KnZ9A3qeAjZteIpkowEFfUeMPNg2dvvoFRJA9zqxSw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@resvg/resvg-js@2.4.1':
+    resolution: {integrity: sha512-wTOf1zerZX8qYcMmLZw3czR4paI4hXqPjShNwJRh5DeHxvgffUS5KM7XwxtbIheUW6LVYT5fhT2AJiP6mU7U4A==}
+    engines: {node: '>= 10'}
+
   '@rollup/plugin-babel@5.3.1':
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
     engines: {node: '>= 10.0.0'}
@@ -3030,6 +3109,30 @@ packages:
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
+
+  '@turf/boolean-clockwise@6.5.0':
+    resolution: {integrity: sha512-45+C7LC5RMbRWrxh3Z0Eihsc8db1VGBO5d9BLTOAwU4jR6SgsunTfRWR16X7JUwIDYlCVEmnjcXJNi/kIU3VIw==}
+
+  '@turf/clone@6.5.0':
+    resolution: {integrity: sha512-mzVtTFj/QycXOn6ig+annKrM6ZlimreKYz6f/GSERytOpgzodbQyOgkfwru100O1KQhhjSudKK4DsQ0oyi9cTw==}
+
+  '@turf/flatten@6.5.0':
+    resolution: {integrity: sha512-IBZVwoNLVNT6U/bcUUllubgElzpMsNoCw8tLqBw6dfYg9ObGmpEjf9BIYLr7a2Yn5ZR4l7YIj2T7kD5uJjZADQ==}
+
+  '@turf/helpers@6.5.0':
+    resolution: {integrity: sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==}
+
+  '@turf/invariant@6.5.0':
+    resolution: {integrity: sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==}
+
+  '@turf/meta@3.14.0':
+    resolution: {integrity: sha512-OtXqLQuR9hlQ/HkAF/OdzRea7E0eZK1ay8y8CBXkoO2R6v34CsDrWYLMSo0ZzMsaQDpKo76NPP2GGo+PyG1cSg==}
+
+  '@turf/meta@6.5.0':
+    resolution: {integrity: sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==}
+
+  '@turf/rewind@6.5.0':
+    resolution: {integrity: sha512-IoUAMcHWotBWYwSYuYypw/LlqZmO+wcBpn8ysrBNbazkFNkLf3btSDZMkKJO/bvOzl55imr/Xj4fi3DdsLsbzQ==}
 
   '@types/assert@1.5.11':
     resolution: {integrity: sha512-FjS1mxq2dlGr9N4z72/DO+XmyRS3ZZIoVn998MEopAN/OmyN28F4yumRL5pOw2z+hbFLuWGYuF2rrw5p11xM5A==}
@@ -3558,6 +3661,42 @@ packages:
     peerDependencies:
       vite: ^2.9.0 || ^3.0.0-0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0
 
+  '@visactor/vchart@2.0.2':
+    resolution: {integrity: sha512-9ERESHbN/HaTlNmT9yom28IsoJuIW0hO4ngrtXwvQwqMEOoimly+BaDUiq0emFSUXGnDTbv5sVai1OQT/17xyA==}
+
+  '@visactor/vdataset@1.0.9':
+    resolution: {integrity: sha512-8OJWm8rZ1ss46r7BgO7L7se0qb28Ygk1yd999tV5SsN7R06sgB08l6ZP8dbvAXlYW08FWLYXc5RmCTRVG8mL2Q==}
+
+  '@visactor/vlayouts@1.0.9':
+    resolution: {integrity: sha512-85oR9zRfxidq2TCScSAfPWUYeqxIcH4LSKNQPKBmXc1f+nqw7SV3NKT/oiYfrqrbdNxF29jn06R2eaGlo3LaDg==}
+
+  '@visactor/vrender-animate@1.0.9':
+    resolution: {integrity: sha512-9gkzQuVx2SP5YmdHslRdZK3dH8q0sZRqEi7XlmB7fL++pvDuJy5EGWTIUXPvAL/67hLpQKJy/Oe3C+4RxPpQ1A==}
+
+  '@visactor/vrender-components@1.0.9':
+    resolution: {integrity: sha512-3NDFyKOlPjHICgrig14E1IrXXkLFQWOicX3jNH9/QqPjgRF4o6orp3ZeJs3Qy451qXTum4/2GUgsNq2sC8IHyg==}
+
+  '@visactor/vrender-core@1.0.9':
+    resolution: {integrity: sha512-r33hSBIPvbMJuLhJ8LLBlwkKLqwDg+nl2MRoQfyy4f4VrGg1yBmF576lbj7TCifLN8mtfhrWHZ+Hb0Q65Alghg==}
+
+  '@visactor/vrender-kits@1.0.9':
+    resolution: {integrity: sha512-X5CCWEJt4AcfIcbkdScKJjr7tRBCta7SrltsjeMH+RDmNEzPxNJhvxgzpxePAOaWmJVR8TEKgT3cyx3bOU+EHg==}
+
+  '@visactor/vscale@1.0.6':
+    resolution: {integrity: sha512-E6ySrzOIyL85luy5dKPpKzaCjf/hkLFF/mAn37Lv8XJWhyxWjYO29GM7cIlqDNCKAY0qsONPnfmgdGX+Hoe5vg==}
+
+  '@visactor/vscale@1.0.9':
+    resolution: {integrity: sha512-8u7ousY+Yo9smgcPyFePYl45sD4VXciQf9JOAc2jncNFIyZch7/2Li2CvqL3HPrdenjrl1twAVc5C5IPbyEUyQ==}
+
+  '@visactor/vutils-extension@2.0.2':
+    resolution: {integrity: sha512-qknQZmr6qnLrMOUXMnuLyFln3wTtOhFUNYoNpYyupwrPCIRleR8LKnBycJ1TRANFBZELSI1R5471T9hENUgz2w==}
+
+  '@visactor/vutils@1.0.6':
+    resolution: {integrity: sha512-87/AYLrjY1rtvIT0N/9S+sESialMQUKYv7MDjLjUo37u0hmeL/AwRSGBSvjxdxayKHOmdwUK1BLpQrDIrssKLg==}
+
+  '@visactor/vutils@1.0.9':
+    resolution: {integrity: sha512-78Y7ZbpViscZuGIfsUAahilBHnMpAjIhbTvS4g04H4DOu/a5kNyvF6J2a4u4JFGMbazdzY9L1lDQ9koNdpviGQ==}
+
   '@vite-pwa/vitepress@1.0.0':
     resolution: {integrity: sha512-i5RFah4urA6tZycYlGyBslVx8cVzbZBcARJLDg5rWMfAkRmyLtpRU6usGfVOwyN9kjJ2Bkm+gBHXF1hhr7HptQ==}
     peerDependencies:
@@ -3841,6 +3980,9 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  abs-svg-path@0.1.1:
+    resolution: {integrity: sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==}
+
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
@@ -4046,6 +4188,9 @@ packages:
 
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
+  array-source@0.0.4:
+    resolution: {integrity: sha512-frNdc+zBn80vipY+GdcJkLEbMWj3xmzArYApmUGxoiV8uAu/ygcs9icPdsGdA26h0MkHUMW6EN2piIvVx+M5Mw==}
 
   array-timsort@1.0.3:
     resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
@@ -4606,6 +4751,14 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  concat-stream@1.4.11:
+    resolution: {integrity: sha512-X3JMh8+4je3U1cQpG87+f9lXHDrqcb2MVLg9L7o8b1UZ0DzhRrUpdn65ttzu10PpJPPI3MQNkis+oha6TSA9Mw==}
+    engines: {'0': node >= 0.8}
+
+  concat-stream@2.0.0:
+    resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
+    engines: {'0': node >= 6.0}
+
   concurrently@9.1.2:
     resolution: {integrity: sha512-H9MWcoPsYddwbOGM6difjVwVZHl63nwMEwDJG/L7VGtuaJhb12h2caPG2tVPWs7emuYix252iGfqOyrz1GczTQ==}
     engines: {node: '>=18'}
@@ -4849,6 +5002,9 @@ packages:
     resolution: {integrity: sha512-zDGn1K/tfZwEnoGOcHc0H4XazqAAXAuDpcYw9mUnUjATjqljyCNGJv8uEvbvxGaGHaVshxMecyl6oc6uKzRfbw==}
     engines: {node: '>=0.10'}
 
+  d3-array@1.2.4:
+    resolution: {integrity: sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==}
+
   d3-array@2.12.1:
     resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
 
@@ -4888,6 +5044,10 @@ packages:
     resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
     engines: {node: '>=12'}
 
+  d3-dsv@2.0.0:
+    resolution: {integrity: sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==}
+    hasBin: true
+
   d3-dsv@3.0.1:
     resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
     engines: {node: '>=12'}
@@ -4909,9 +5069,15 @@ packages:
     resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
     engines: {node: '>=12'}
 
+  d3-geo@1.12.1:
+    resolution: {integrity: sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==}
+
   d3-geo@3.1.1:
     resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
     engines: {node: '>=12'}
+
+  d3-hexbin@0.2.2:
+    resolution: {integrity: sha512-KS3fUT2ReD4RlGCjvCEm1RgMtp2NFZumdMu4DBzQK8AZv3fXRM6Xm8I4fSU07UXvH4xxg03NwWKWdvxfS/yc4w==}
 
   d3-hierarchy@3.1.2:
     resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
@@ -5787,6 +5953,9 @@ packages:
   file-saver@2.0.5:
     resolution: {integrity: sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==}
 
+  file-source@0.6.1:
+    resolution: {integrity: sha512-1R1KneL7eTXmXfKxC10V/9NeGOdbsAXJ+lQ//fvvcHUgtaZcZDWNJNblxAoVOyV1cj45pOtUrR3vZTBwqcW8XA==}
+
   filelist@1.0.4:
     resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
 
@@ -5980,6 +6149,20 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  geobuf@3.0.2:
+    resolution: {integrity: sha512-ASgKwEAQQRnyNFHNvpd5uAwstbVYmiTW0Caw3fBb509tNTqXyAAPMyFs5NNihsLZhLxU1j/kjFhkhLWA9djuVg==}
+    hasBin: true
+
+  geojson-dissolve@3.1.0:
+    resolution: {integrity: sha512-JXHfn+A3tU392HA703gJbjmuHaQOAE/C1KzbELCczFRFux+GdY6zt1nKb1VMBHp4LWeE7gUY2ql+g06vJqhiwQ==}
+
+  geojson-flatten@0.2.4:
+    resolution: {integrity: sha512-LiX6Jmot8adiIdZ/fthbcKKPOfWjTQchX/ggHnwMZ2e4b0I243N1ANUos0LvnzepTEsj0+D4fIJ5bKhBrWnAHA==}
+    hasBin: true
+
+  geojson-linestring-dissolve@0.0.1:
+    resolution: {integrity: sha512-Y8I2/Ea28R/Xeki7msBcpMvJL2TaPfaPKP8xqueJfQ9/jEhps+iOJxOR2XCBGgVb12Z6XnDb1CMbaPfLepsLaw==}
+
   get-amd-module-type@6.0.0:
     resolution: {integrity: sha512-hFM7oivtlgJ3d6XWD6G47l8Wyh/C6vFw5G24Kk1Tbq85yh5gcM8Fne5/lFhiuxB+RT6+SI7I1ThB9lG4FBh3jw==}
     engines: {node: '>=18'}
@@ -6015,6 +6198,10 @@ packages:
     resolution: {integrity: sha512-jZV7n6jGE3Gt7fgSTJoz91Ak5MuTLwMwkoYdjxuJ/AmjIsE1UC03y/IWkZCQGEvVNS9qoRNwy5BCqxImv0FVeA==}
     engines: {node: '>=0.12.0'}
 
+  get-stdin@6.0.0:
+    resolution: {integrity: sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==}
+    engines: {node: '>=4'}
+
   get-stdin@9.0.0:
     resolution: {integrity: sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==}
     engines: {node: '>=12'}
@@ -6047,6 +6234,9 @@ packages:
 
   getpass@0.1.7:
     resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
+
+  gifuct-js@2.1.2:
+    resolution: {integrity: sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg==}
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
@@ -6644,6 +6834,9 @@ packages:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
 
+  isarray@0.0.1:
+    resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
+
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
@@ -6884,6 +7077,9 @@ packages:
 
   js-base64@3.7.7:
     resolution: {integrity: sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==}
+
+  js-binary-schema-parser@2.0.3:
+    resolution: {integrity: sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -7162,6 +7358,9 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  lottie-web@5.13.0:
+    resolution: {integrity: sha512-+gfBXl6sxXMPe8tKQm7qzLnUy5DUPJPKIyRHwtpCpyUEYjHYRJC/5gjUvdkuO2c3JllrPtHXH5UJJK8LRYl5yQ==}
 
   loupe@3.1.3:
     resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
@@ -7497,6 +7696,12 @@ packages:
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minimist@1.2.0:
+    resolution: {integrity: sha512-7Wl+Jz+IGWuSdgsQEJ4JunV0si/iMhg42MnQQG6h1R6TNeVenp4U9x5CC5v/gYqz/fENLQITAWXidNtVL0NNbw==}
+
+  minimist@1.2.6:
+    resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -7880,6 +8085,9 @@ packages:
     resolution: {integrity: sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==}
     engines: {node: '>=18'}
 
+  parse-svg-path@0.1.2:
+    resolution: {integrity: sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==}
+
   parse5@7.2.1:
     resolution: {integrity: sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==}
 
@@ -7932,6 +8140,9 @@ packages:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
     engines: {node: 20 || >=22}
 
+  path-source@0.1.3:
+    resolution: {integrity: sha512-dWRHm5mIw5kw0cs3QZLNmpUWty48f5+5v9nWD2dw3Y0Hf+s01Ag8iJEWV0Sm0kocE8kK27DrIowha03e1YR+Qw==}
+
   path-to-regexp@0.1.10:
     resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
 
@@ -7956,6 +8167,10 @@ packages:
 
   pause-stream@0.0.11:
     resolution: {integrity: sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==}
+
+  pbf@3.3.0:
+    resolution: {integrity: sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==}
+    hasBin: true
 
   pcg@1.0.0:
     resolution: {integrity: sha512-6wjoSJZ4TEJhI0rLDOKd5mOu6TwS4svn9oBaRsD1PCrhlDNLWAaTimWJgBABmIGJxzkI+RbaHJYRLGVf9QFE5Q==}
@@ -8054,6 +8269,9 @@ packages:
   pngjs@6.0.0:
     resolution: {integrity: sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg==}
     engines: {node: '>=12.13.0'}
+
+  point-at-length@1.1.0:
+    resolution: {integrity: sha512-nNHDk9rNEh/91o2Y8kHLzBLNpLf80RYd2gCun9ss+V0ytRSf6XhryBTx071fesktjbachRmGuUbId+JQmzhRXw==}
 
   points-on-curve@0.2.0:
     resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
@@ -8176,6 +8394,9 @@ packages:
   property-information@7.0.0:
     resolution: {integrity: sha512-7D/qOz/+Y4X/rzSB6jKxKUsQnphO046ei8qxG59mtM3RG3DHgTK81HrxrmoDVINJb8NKT5ZsRbwHvQ6B68Iyhg==}
 
+  protocol-buffers-schema@3.6.0:
+    resolution: {integrity: sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -8271,6 +8492,9 @@ packages:
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
     engines: {node: '>=6'}
+
+  readable-stream@1.1.14:
+    resolution: {integrity: sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==}
 
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
@@ -8423,6 +8647,9 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  resolve-protobuf-schema@2.1.0:
+    resolution: {integrity: sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==}
+
   resolve.exports@2.0.2:
     resolution: {integrity: sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==}
     engines: {node: '>=10'}
@@ -8503,6 +8730,9 @@ packages:
     resolution: {integrity: sha512-Noe455xmA96nnqH5piFtLobsGbCij7Tu+tb3c1vYjNbTkfzGqXqQXG3wJaYXkRZuQ0vEYN4bhwg7QnIrqB5B+w==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  roughjs@4.5.2:
+    resolution: {integrity: sha512-2xSlLDKdsWyFxrveYWk9YQ/Y9UfK38EAMRNkYkMqYBJvPX8abCa9PN0x3w02H8Oa6/0bcZICJU+U95VumPqseg==}
 
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
@@ -8654,6 +8884,10 @@ packages:
     resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
     engines: {node: '>=8'}
 
+  shapefile@0.6.6:
+    resolution: {integrity: sha512-rLGSWeK2ufzCVx05wYd+xrWnOOdSV7xNUW5/XFgx3Bc02hBkpMlrd2F1dDII7/jhWzv0MSyBFh5uJIy9hLdfuw==}
+    hasBin: true
+
   sharp@0.33.5:
     resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -8716,8 +8950,18 @@ packages:
     resolution: {integrity: sha512-0LxHn+P1lF5r2WwVB/za3hLRIsYoLaNq1CXqjbrs3ZvLuvlWnRKrUjEWzV7umZL7hpQ7xULiQMV+0iXdRa5iFg==}
     engines: {node: '>=14.16'}
 
+  simple-statistics@7.8.8:
+    resolution: {integrity: sha512-CUtP0+uZbcbsFpqEyvNDYjJCl+612fNgjT8GaVuvMG7tBuJg8gXGpsP5M7X658zy0IcepWOZ6nPBu1Qb9ezA1w==}
+
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
+
+  simplify-geojson@1.0.5:
+    resolution: {integrity: sha512-02l1W4UipP5ivNVq6kX15mAzCRIV1oI3tz0FUEyOsNiv1ltuFDjbNhO+nbv/xhbDEtKqWLYuzpWhUsJrjR/ypA==}
+    hasBin: true
+
+  simplify-geometry@0.0.2:
+    resolution: {integrity: sha512-ZEyrplkqgCqDlL7V8GbbYgTLlcnNF+MWWUdy8s8ZeJru50bnI71rDew/I+HG36QS2mPOYAq1ZjwNXxHJ8XOVBw==}
 
   sirv@3.0.1:
     resolution: {integrity: sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==}
@@ -8756,6 +9000,9 @@ packages:
   slice-ansi@7.1.0:
     resolution: {integrity: sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==}
     engines: {node: '>=18'}
+
+  slice-source@0.4.1:
+    resolution: {integrity: sha512-YiuPbxpCj4hD9Qs06hGAz/OZhQ0eDuALN0lRWJez0eD/RevzKqGdUx1IOMUnXgpr+sXZLq3g8ERwbAH0bCb8vg==}
 
   smob@1.5.0:
     resolution: {integrity: sha512-g6T+p7QO8npa+/hNx9ohv1E5pVCmWrVCUzUXJyLdMmftX6ER0oiWY/w9knEonLpnOp6b6FenKnMfR8gqwWdwig==}
@@ -8798,6 +9045,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   sourcemap-codec@1.4.8:
     resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
@@ -8891,6 +9139,9 @@ packages:
   stream-combiner@0.0.4:
     resolution: {integrity: sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==}
 
+  stream-source@0.3.5:
+    resolution: {integrity: sha512-ZuEDP9sgjiAwUVoDModftG0JtYiLUV8K4ljYD1VyUMRWtbVf92474o4kuuul43iZ8t/hRuiDAx1dIJSvirrK/g==}
+
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
@@ -8926,6 +9177,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@0.10.31:
+    resolution: {integrity: sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==}
 
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
@@ -9098,6 +9352,10 @@ packages:
     resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
     engines: {node: '>=18'}
 
+  text-encoding@0.6.4:
+    resolution: {integrity: sha512-hJnc6Qg3dWoOMkqP53F0dzRIgtmsAge09kxUIqGrEUS4qr5rWLckGYaQAVr+opBrIMRErGgy6f5aPnyPpyGRfg==}
+    deprecated: no longer maintained
+
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -9174,6 +9432,14 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  topojson-client@3.1.0:
+    resolution: {integrity: sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==}
+    hasBin: true
+
+  topojson-server@3.0.1:
+    resolution: {integrity: sha512-/VS9j/ffKr2XAOjlZ9CgyyeLmgJ9dMwq6Y0YEON8O7p/tGGk+dCWnrE03zEdu7i4L7YsFZLEPZPzCvcB7lEEXw==}
+    hasBin: true
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -9304,6 +9570,12 @@ packages:
 
   typedarray-to-buffer@3.1.5:
     resolution: {integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==}
+
+  typedarray@0.0.6:
+    resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+
+  typedarray@0.0.7:
+    resolution: {integrity: sha512-ueeb9YybpjhivjbHP2LdFDAjbS948fGEPj+ACAMs4xCMmh72OCOMQWBQKlaN4ZNQ04yfLSDLSx1tGRIoWimObQ==}
 
   typedoc-plugin-markdown@4.4.2:
     resolution: {integrity: sha512-kJVkU2Wd+AXQpyL6DlYXXRrfNrHrEIUgiABWH8Z+2Lz5Sq6an4dQ/hfvP75bbokjNDUskOdFlEEm/0fSVyC7eg==}
@@ -13212,6 +13484,57 @@ snapshots:
 
   '@polka/url@1.0.0-next.28': {}
 
+  '@resvg/resvg-js-android-arm-eabi@2.4.1':
+    optional: true
+
+  '@resvg/resvg-js-android-arm64@2.4.1':
+    optional: true
+
+  '@resvg/resvg-js-darwin-arm64@2.4.1':
+    optional: true
+
+  '@resvg/resvg-js-darwin-x64@2.4.1':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm-gnueabihf@2.4.1':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm64-gnu@2.4.1':
+    optional: true
+
+  '@resvg/resvg-js-linux-arm64-musl@2.4.1':
+    optional: true
+
+  '@resvg/resvg-js-linux-x64-gnu@2.4.1':
+    optional: true
+
+  '@resvg/resvg-js-linux-x64-musl@2.4.1':
+    optional: true
+
+  '@resvg/resvg-js-win32-arm64-msvc@2.4.1':
+    optional: true
+
+  '@resvg/resvg-js-win32-ia32-msvc@2.4.1':
+    optional: true
+
+  '@resvg/resvg-js-win32-x64-msvc@2.4.1':
+    optional: true
+
+  '@resvg/resvg-js@2.4.1':
+    optionalDependencies:
+      '@resvg/resvg-js-android-arm-eabi': 2.4.1
+      '@resvg/resvg-js-android-arm64': 2.4.1
+      '@resvg/resvg-js-darwin-arm64': 2.4.1
+      '@resvg/resvg-js-darwin-x64': 2.4.1
+      '@resvg/resvg-js-linux-arm-gnueabihf': 2.4.1
+      '@resvg/resvg-js-linux-arm64-gnu': 2.4.1
+      '@resvg/resvg-js-linux-arm64-musl': 2.4.1
+      '@resvg/resvg-js-linux-x64-gnu': 2.4.1
+      '@resvg/resvg-js-linux-x64-musl': 2.4.1
+      '@resvg/resvg-js-win32-arm64-msvc': 2.4.1
+      '@resvg/resvg-js-win32-ia32-msvc': 2.4.1
+      '@resvg/resvg-js-win32-x64-msvc': 2.4.1
+
   '@rollup/plugin-babel@5.3.1(@babel/core@7.26.10)(@types/babel__core@7.20.5)(rollup@2.79.2)':
     dependencies:
       '@babel/core': 7.26.10
@@ -13487,6 +13810,40 @@ snapshots:
       vue: 3.5.13(typescript@5.7.3)
 
   '@tootallnate/once@2.0.0': {}
+
+  '@turf/boolean-clockwise@6.5.0':
+    dependencies:
+      '@turf/helpers': 6.5.0
+      '@turf/invariant': 6.5.0
+
+  '@turf/clone@6.5.0':
+    dependencies:
+      '@turf/helpers': 6.5.0
+
+  '@turf/flatten@6.5.0':
+    dependencies:
+      '@turf/helpers': 6.5.0
+      '@turf/meta': 6.5.0
+
+  '@turf/helpers@6.5.0': {}
+
+  '@turf/invariant@6.5.0':
+    dependencies:
+      '@turf/helpers': 6.5.0
+
+  '@turf/meta@3.14.0': {}
+
+  '@turf/meta@6.5.0':
+    dependencies:
+      '@turf/helpers': 6.5.0
+
+  '@turf/rewind@6.5.0':
+    dependencies:
+      '@turf/boolean-clockwise': 6.5.0
+      '@turf/clone': 6.5.0
+      '@turf/helpers': 6.5.0
+      '@turf/invariant': 6.5.0
+      '@turf/meta': 6.5.0
 
   '@types/assert@1.5.11': {}
 
@@ -14186,6 +14543,98 @@ snapshots:
     transitivePeerDependencies:
       - vue
 
+  '@visactor/vchart@2.0.2':
+    dependencies:
+      '@visactor/vdataset': 1.0.9
+      '@visactor/vlayouts': 1.0.9
+      '@visactor/vrender-animate': 1.0.9
+      '@visactor/vrender-components': 1.0.9
+      '@visactor/vrender-core': 1.0.9
+      '@visactor/vrender-kits': 1.0.9
+      '@visactor/vscale': 1.0.9
+      '@visactor/vutils': 1.0.9
+      '@visactor/vutils-extension': 2.0.2
+
+  '@visactor/vdataset@1.0.9':
+    dependencies:
+      '@turf/flatten': 6.5.0
+      '@turf/helpers': 6.5.0
+      '@turf/rewind': 6.5.0
+      '@visactor/vutils': 1.0.9
+      d3-dsv: 2.0.0
+      d3-geo: 1.12.1
+      d3-hexbin: 0.2.2
+      d3-hierarchy: 3.1.2
+      eventemitter3: 4.0.7
+      geobuf: 3.0.2
+      geojson-dissolve: 3.1.0
+      path-browserify: 1.0.1
+      pbf: 3.3.0
+      point-at-length: 1.1.0
+      simple-statistics: 7.8.8
+      simplify-geojson: 1.0.5
+      topojson-client: 3.1.0
+
+  '@visactor/vlayouts@1.0.9':
+    dependencies:
+      '@turf/helpers': 6.5.0
+      '@turf/invariant': 6.5.0
+      '@visactor/vscale': 1.0.9
+      '@visactor/vutils': 1.0.9
+      eventemitter3: 4.0.7
+
+  '@visactor/vrender-animate@1.0.9':
+    dependencies:
+      '@visactor/vrender-core': 1.0.9
+      '@visactor/vutils': 1.0.6
+
+  '@visactor/vrender-components@1.0.9':
+    dependencies:
+      '@visactor/vrender-animate': 1.0.9
+      '@visactor/vrender-core': 1.0.9
+      '@visactor/vrender-kits': 1.0.9
+      '@visactor/vscale': 1.0.6
+      '@visactor/vutils': 1.0.6
+
+  '@visactor/vrender-core@1.0.9':
+    dependencies:
+      '@visactor/vutils': 1.0.6
+      color-convert: 2.0.1
+
+  '@visactor/vrender-kits@1.0.9':
+    dependencies:
+      '@resvg/resvg-js': 2.4.1
+      '@visactor/vrender-core': 1.0.9
+      '@visactor/vutils': 1.0.6
+      gifuct-js: 2.1.2
+      lottie-web: 5.13.0
+      roughjs: 4.5.2(patch_hash=vxb6t6fqvzyhwhtjiliqr25jyq)
+
+  '@visactor/vscale@1.0.6':
+    dependencies:
+      '@visactor/vutils': 1.0.6
+
+  '@visactor/vscale@1.0.9':
+    dependencies:
+      '@visactor/vutils': 1.0.9
+
+  '@visactor/vutils-extension@2.0.2':
+    dependencies:
+      '@visactor/vdataset': 1.0.9
+      '@visactor/vutils': 1.0.9
+
+  '@visactor/vutils@1.0.6':
+    dependencies:
+      '@turf/helpers': 6.5.0
+      '@turf/invariant': 6.5.0
+      eventemitter3: 4.0.7
+
+  '@visactor/vutils@1.0.9':
+    dependencies:
+      '@turf/helpers': 6.5.0
+      '@turf/invariant': 6.5.0
+      eventemitter3: 4.0.7
+
   '@vite-pwa/vitepress@1.0.0(vite-plugin-pwa@1.0.0(vite@6.1.1(@types/node@22.13.5)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(workbox-build@7.1.1(@types/babel__core@7.20.5))(workbox-window@7.3.0))':
     dependencies:
       vite-plugin-pwa: 1.0.0(vite@6.1.1(@types/node@22.13.5)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))(workbox-build@7.1.1(@types/babel__core@7.20.5))(workbox-window@7.3.0)
@@ -14560,6 +15009,8 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
+  abs-svg-path@0.1.1: {}
+
   abstract-logging@2.0.1: {}
 
   accepts@1.3.8:
@@ -14748,6 +15199,8 @@ snapshots:
       is-array-buffer: 3.0.5
 
   array-flatten@1.1.1: {}
+
+  array-source@0.0.4: {}
 
   array-timsort@1.0.3: {}
 
@@ -15384,6 +15837,19 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  concat-stream@1.4.11:
+    dependencies:
+      inherits: 2.0.4
+      readable-stream: 1.1.14
+      typedarray: 0.0.7
+
+  concat-stream@2.0.0:
+    dependencies:
+      buffer-from: 1.1.2
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      typedarray: 0.0.6
+
   concurrently@9.1.2:
     dependencies:
       chalk: 4.1.2
@@ -15777,6 +16243,8 @@ snapshots:
 
   cytoscape@3.31.0: {}
 
+  d3-array@1.2.4: {}
+
   d3-array@2.12.1:
     dependencies:
       internmap: 1.0.1
@@ -15816,6 +16284,12 @@ snapshots:
       d3-dispatch: 3.0.1
       d3-selection: 3.0.0
 
+  d3-dsv@2.0.0:
+    dependencies:
+      commander: 2.20.3
+      iconv-lite: 0.4.24
+      rw: 1.3.3
+
   d3-dsv@3.0.1:
     dependencies:
       commander: 7.2.0
@@ -15836,9 +16310,15 @@ snapshots:
 
   d3-format@3.1.0: {}
 
+  d3-geo@1.12.1:
+    dependencies:
+      d3-array: 1.2.4
+
   d3-geo@3.1.1:
     dependencies:
       d3-array: 3.2.4
+
+  d3-hexbin@0.2.2: {}
 
   d3-hierarchy@3.1.2: {}
 
@@ -16970,6 +17450,10 @@ snapshots:
 
   file-saver@2.0.5: {}
 
+  file-source@0.6.1:
+    dependencies:
+      stream-source: 0.3.5
+
   filelist@1.0.4:
     dependencies:
       minimatch: 5.1.6
@@ -17209,6 +17693,27 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  geobuf@3.0.2:
+    dependencies:
+      concat-stream: 2.0.0
+      pbf: 3.3.0
+      shapefile: 0.6.6
+
+  geojson-dissolve@3.1.0:
+    dependencies:
+      '@turf/meta': 3.14.0
+      geojson-flatten: 0.2.4
+      geojson-linestring-dissolve: 0.0.1
+      topojson-client: 3.1.0
+      topojson-server: 3.0.1
+
+  geojson-flatten@0.2.4:
+    dependencies:
+      get-stdin: 6.0.0
+      minimist: 1.2.0
+
+  geojson-linestring-dissolve@0.0.1: {}
+
   get-amd-module-type@6.0.0:
     dependencies:
       ast-module-types: 6.0.0
@@ -17255,6 +17760,8 @@ snapshots:
 
   get-stdin@5.0.1: {}
 
+  get-stdin@6.0.0: {}
+
   get-stdin@9.0.0: {}
 
   get-stream@4.1.0:
@@ -17286,6 +17793,10 @@ snapshots:
   getpass@0.1.7:
     dependencies:
       assert-plus: 1.0.0
+
+  gifuct-js@2.1.2:
+    dependencies:
+      js-binary-schema-parser: 2.0.3
 
   github-slugger@2.0.0: {}
 
@@ -17873,6 +18384,8 @@ snapshots:
     dependencies:
       is-docker: 2.2.1
 
+  isarray@0.0.1: {}
+
   isarray@1.0.0: {}
 
   isarray@2.0.5: {}
@@ -18337,6 +18850,8 @@ snapshots:
 
   js-base64@3.7.7: {}
 
+  js-binary-schema-parser@2.0.3: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.1:
@@ -18635,6 +19150,8 @@ snapshots:
   long@5.2.3: {}
 
   longest-streak@3.1.0: {}
+
+  lottie-web@5.13.0: {}
 
   loupe@3.1.3: {}
 
@@ -19138,6 +19655,10 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.1
 
+  minimist@1.2.0: {}
+
+  minimist@1.2.6: {}
+
   minimist@1.2.8: {}
 
   minipass@7.1.2: {}
@@ -19549,6 +20070,8 @@ snapshots:
       index-to-position: 0.1.2
       type-fest: 4.35.0
 
+  parse-svg-path@0.1.2: {}
+
   parse5@7.2.1:
     dependencies:
       entities: 4.5.0
@@ -19585,6 +20108,11 @@ snapshots:
       lru-cache: 11.0.2
       minipass: 7.1.2
 
+  path-source@0.1.3:
+    dependencies:
+      array-source: 0.0.4
+      file-source: 0.6.1
+
   path-to-regexp@0.1.10: {}
 
   path-to-regexp@8.2.0: {}
@@ -19600,6 +20128,11 @@ snapshots:
   pause-stream@0.0.11:
     dependencies:
       through: 2.3.8
+
+  pbf@3.3.0:
+    dependencies:
+      ieee754: 1.2.1
+      resolve-protobuf-schema: 2.1.0
 
   pcg@1.0.0:
     dependencies:
@@ -19702,6 +20235,12 @@ snapshots:
   pngjs@3.4.0: {}
 
   pngjs@6.0.0: {}
+
+  point-at-length@1.1.0:
+    dependencies:
+      abs-svg-path: 0.1.1
+      isarray: 0.0.1
+      parse-svg-path: 0.1.2
 
   points-on-curve@0.2.0: {}
 
@@ -19822,6 +20361,8 @@ snapshots:
 
   property-information@7.0.0: {}
 
+  protocol-buffers-schema@3.6.0: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -19918,6 +20459,13 @@ snapshots:
       js-yaml: 3.14.1
       pify: 4.0.1
       strip-bom: 3.0.0
+
+  readable-stream@1.1.14:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 0.0.1
+      string_decoder: 0.10.31
 
   readable-stream@2.3.8:
     dependencies:
@@ -20107,6 +20655,10 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  resolve-protobuf-schema@2.1.0:
+    dependencies:
+      protocol-buffers-schema: 3.6.0
+
   resolve.exports@2.0.2: {}
 
   resolve@1.22.10:
@@ -20216,7 +20768,13 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.40.0
       fsevents: 2.3.3
 
-  roughjs@4.6.6(patch_hash=3543d47108cb41b68ec6a671c0e1f9d0cfe2ce524fea5b0992511ae84c3c6b64):
+  roughjs@4.5.2(patch_hash=vxb6t6fqvzyhwhtjiliqr25jyq):
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
+  roughjs@4.6.6(patch_hash=vxb6t6fqvzyhwhtjiliqr25jyq):
     dependencies:
       hachure-fill: 0.5.2
       path-data-parser: 0.1.0
@@ -20425,6 +20983,15 @@ snapshots:
     dependencies:
       kind-of: 6.0.3
 
+  shapefile@0.6.6:
+    dependencies:
+      array-source: 0.0.4
+      commander: 2.20.3
+      path-source: 0.1.3
+      slice-source: 0.4.1
+      stream-source: 0.3.5
+      text-encoding: 0.6.4
+
   sharp@0.33.5:
     dependencies:
       color: 4.2.3
@@ -20518,9 +21085,19 @@ snapshots:
 
   simple-bin-help@1.8.0: {}
 
+  simple-statistics@7.8.8: {}
+
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
+
+  simplify-geojson@1.0.5:
+    dependencies:
+      concat-stream: 1.4.11
+      minimist: 1.2.6
+      simplify-geometry: 0.0.2
+
+  simplify-geometry@0.0.2: {}
 
   sirv@3.0.1:
     dependencies:
@@ -20559,6 +21136,8 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 5.0.0
+
+  slice-source@0.4.1: {}
 
   smob@1.5.0: {}
 
@@ -20729,6 +21308,8 @@ snapshots:
     dependencies:
       duplexer: 0.1.2
 
+  stream-source@0.3.5: {}
+
   string-argv@0.3.2: {}
 
   string-length@4.0.2:
@@ -20792,6 +21373,8 @@ snapshots:
       call-bind: 1.0.8
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  string_decoder@0.10.31: {}
 
   string_decoder@1.1.1:
     dependencies:
@@ -20994,6 +21577,8 @@ snapshots:
       glob: 10.4.5
       minimatch: 9.0.5
 
+  text-encoding@0.6.4: {}
+
   thenify-all@1.6.0:
     dependencies:
       thenify: 3.3.1
@@ -21054,6 +21639,14 @@ snapshots:
   toad-cache@3.7.0: {}
 
   toidentifier@1.0.1: {}
+
+  topojson-client@3.1.0:
+    dependencies:
+      commander: 2.20.3
+
+  topojson-server@3.0.1:
+    dependencies:
+      commander: 2.20.3
 
   totalist@3.0.1: {}
 
@@ -21179,6 +21772,10 @@ snapshots:
   typedarray-to-buffer@3.1.5:
     dependencies:
       is-typedarray: 1.0.0
+
+  typedarray@0.0.6: {}
+
+  typedarray@0.0.7: {}
 
   typedoc-plugin-markdown@4.4.2(typedoc@0.27.8(typescript@5.7.3)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,12 @@ importers:
       '@visactor/vchart':
         specifier: ^2.0.2
         version: 2.0.2
+      '@visactor/vtable':
+        specifier: ^1.19.9
+        version: 1.19.9
+      '@visactor/vtable-gantt':
+        specifier: ^1.19.9
+        version: 1.19.9
       cytoscape:
         specifier: ^3.29.3
         version: 3.31.0
@@ -3664,6 +3670,9 @@ packages:
   '@visactor/vchart@2.0.2':
     resolution: {integrity: sha512-9ERESHbN/HaTlNmT9yom28IsoJuIW0hO4ngrtXwvQwqMEOoimly+BaDUiq0emFSUXGnDTbv5sVai1OQT/17xyA==}
 
+  '@visactor/vdataset@0.18.18':
+    resolution: {integrity: sha512-lye23zpineMKV42JmuJaOY3fgl7aWhyDIwK9dWooqZzP14AFukPoK7ZvUeuKZihLrHxqtCg2VWEjovnh9O1RUg==}
+
   '@visactor/vdataset@1.0.9':
     resolution: {integrity: sha512-8OJWm8rZ1ss46r7BgO7L7se0qb28Ygk1yd999tV5SsN7R06sgB08l6ZP8dbvAXlYW08FWLYXc5RmCTRVG8mL2Q==}
 
@@ -3682,14 +3691,35 @@ packages:
   '@visactor/vrender-kits@1.0.9':
     resolution: {integrity: sha512-X5CCWEJt4AcfIcbkdScKJjr7tRBCta7SrltsjeMH+RDmNEzPxNJhvxgzpxePAOaWmJVR8TEKgT3cyx3bOU+EHg==}
 
+  '@visactor/vscale@0.18.18':
+    resolution: {integrity: sha512-iRG4kv+5Fv4KX3AxEfV95XU3I6OmF0QizyAhqHxKa7L1MaT+MRvDDk5zHWf1E8gialLbL2xDe3GnT6g/4u5jhA==}
+
   '@visactor/vscale@1.0.6':
     resolution: {integrity: sha512-E6ySrzOIyL85luy5dKPpKzaCjf/hkLFF/mAn37Lv8XJWhyxWjYO29GM7cIlqDNCKAY0qsONPnfmgdGX+Hoe5vg==}
 
   '@visactor/vscale@1.0.9':
     resolution: {integrity: sha512-8u7ousY+Yo9smgcPyFePYl45sD4VXciQf9JOAc2jncNFIyZch7/2Li2CvqL3HPrdenjrl1twAVc5C5IPbyEUyQ==}
 
+  '@visactor/vtable-editors@1.19.9':
+    resolution: {integrity: sha512-5Op1HVGvvnANltkeiOV4GJGo7vnedQcIMqgBSXEIYM2OxjtdrfXUkbWrJ4pyBBQTQeLanFDz5iHWFfOf5nabgg==}
+
+  '@visactor/vtable-gantt@1.19.9':
+    resolution: {integrity: sha512-pnYsbWtci+uCfM9gW3NA/W8kWXw5PCrfs6SFh/NWFZQFDx2czyTPaunTKH7sgYrFS85xyAIPic4BUKEoXkjsYg==}
+
+  '@visactor/vtable@1.19.9':
+    resolution: {integrity: sha512-3ZK/7E0s9G1Ne+PZ+/qGmt0Mmy1iTEYxxh1I1RXBww7rNjA/mz2LyKC2nvQmpTHs5Rvv5RU+ECOehU7l+Bpl8A==}
+
+  '@visactor/vutils-extension@1.11.14':
+    resolution: {integrity: sha512-vfViZphXJBH0NwCHIoe8S1/+tDtykEKIfsLMIHprh7Azv7fVSB1eotG00SAegK75E18ARQGNXF1DxixUFiXSIQ==}
+
   '@visactor/vutils-extension@2.0.2':
     resolution: {integrity: sha512-qknQZmr6qnLrMOUXMnuLyFln3wTtOhFUNYoNpYyupwrPCIRleR8LKnBycJ1TRANFBZELSI1R5471T9hENUgz2w==}
+
+  '@visactor/vutils@0.18.18':
+    resolution: {integrity: sha512-byEJefqxiCz3UWe+YedEVjsdPtnJOAtKdRYi4qT9ojgACdd6QqlWs53Eb7PlMZgWDxVxqkxJP2bZnRKw+ME0Xg==}
+
+  '@visactor/vutils@0.19.7':
+    resolution: {integrity: sha512-1SSnkZgX1p/rSVIFEibrpN6rDdLfdETSI6lJI5JwV8I2paluM1mqz3jEeT3McmWygd/wyUVKAyoRxGXFKAsKEw==}
 
   '@visactor/vutils@1.0.6':
     resolution: {integrity: sha512-87/AYLrjY1rtvIT0N/9S+sESialMQUKYv7MDjLjUo37u0hmeL/AwRSGBSvjxdxayKHOmdwUK1BLpQrDIrssKLg==}
@@ -4955,6 +4985,9 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  cssfontparser@1.2.1:
+    resolution: {integrity: sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==}
+
   cssstyle@4.2.1:
     resolution: {integrity: sha512-9+vem03dMXG7gDmZ62uqmRiMRNtinIZ9ZyuF6BdxzfOD+FdN5hretzynkn0ReS2DO2GSw76RWHs0UmJPI2zUjw==}
     engines: {node: '>=18'}
@@ -5673,6 +5706,7 @@ packages:
   eslint-plugin-markdown@5.1.0:
     resolution: {integrity: sha512-SJeyKko1K6GwI0AN6xeCDToXDkfKZfXcexA6B+O2Wr2btUS9GrC+YgwSyVli5DJnctUHjFXcQ2cqTaAmVoLi2A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: Please use @eslint/markdown instead
     peerDependencies:
       eslint: '>=8'
 
@@ -14555,6 +14589,26 @@ snapshots:
       '@visactor/vutils': 1.0.9
       '@visactor/vutils-extension': 2.0.2
 
+  '@visactor/vdataset@0.18.18':
+    dependencies:
+      '@turf/flatten': 6.5.0
+      '@turf/helpers': 6.5.0
+      '@turf/rewind': 6.5.0
+      '@visactor/vutils': 0.18.18
+      d3-dsv: 2.0.0
+      d3-geo: 1.12.1
+      d3-hexbin: 0.2.2
+      d3-hierarchy: 3.1.2
+      eventemitter3: 4.0.7
+      geobuf: 3.0.2
+      geojson-dissolve: 3.1.0
+      path-browserify: 1.0.1
+      pbf: 3.3.0
+      point-at-length: 1.1.0
+      simple-statistics: 7.8.8
+      simplify-geojson: 1.0.5
+      topojson-client: 3.1.0
+
   '@visactor/vdataset@1.0.9':
     dependencies:
       '@turf/flatten': 6.5.0
@@ -14610,6 +14664,10 @@ snapshots:
       lottie-web: 5.13.0
       roughjs: 4.5.2(patch_hash=vxb6t6fqvzyhwhtjiliqr25jyq)
 
+  '@visactor/vscale@0.18.18':
+    dependencies:
+      '@visactor/vutils': 0.18.18
+
   '@visactor/vscale@1.0.6':
     dependencies:
       '@visactor/vutils': 1.0.6
@@ -14618,10 +14676,53 @@ snapshots:
     dependencies:
       '@visactor/vutils': 1.0.9
 
+  '@visactor/vtable-editors@1.19.9': {}
+
+  '@visactor/vtable-gantt@1.19.9':
+    dependencies:
+      '@visactor/vdataset': 0.18.18
+      '@visactor/vscale': 0.18.18
+      '@visactor/vtable': 1.19.9
+      '@visactor/vtable-editors': 1.19.9
+      '@visactor/vutils': 0.19.7
+      cssfontparser: 1.2.1
+
+  '@visactor/vtable@1.19.9':
+    dependencies:
+      '@visactor/vdataset': 0.18.18
+      '@visactor/vrender-animate': 1.0.9
+      '@visactor/vrender-components': 1.0.9
+      '@visactor/vrender-core': 1.0.9
+      '@visactor/vrender-kits': 1.0.9
+      '@visactor/vscale': 0.18.18
+      '@visactor/vtable-editors': 1.19.9
+      '@visactor/vutils': 0.19.7
+      '@visactor/vutils-extension': 1.11.14
+      cssfontparser: 1.2.1
+      gifuct-js: 2.1.2
+      lodash: 4.17.21
+
+  '@visactor/vutils-extension@1.11.14':
+    dependencies:
+      '@visactor/vdataset': 0.18.18
+      '@visactor/vutils': 0.18.18
+
   '@visactor/vutils-extension@2.0.2':
     dependencies:
       '@visactor/vdataset': 1.0.9
       '@visactor/vutils': 1.0.9
+
+  '@visactor/vutils@0.18.18':
+    dependencies:
+      '@turf/helpers': 6.5.0
+      '@turf/invariant': 6.5.0
+      eventemitter3: 4.0.7
+
+  '@visactor/vutils@0.19.7':
+    dependencies:
+      '@turf/helpers': 6.5.0
+      '@turf/invariant': 6.5.0
+      eventemitter3: 4.0.7
 
   '@visactor/vutils@1.0.6':
     dependencies:
@@ -16141,6 +16242,8 @@ snapshots:
       source-map-js: 1.2.1
 
   cssesc@3.0.0: {}
+
+  cssfontparser@1.2.1: {}
 
   cssstyle@4.2.1:
     dependencies:


### PR DESCRIPTION
## :bookmark_tabs: Summary

Brief description about the content of your PR.

This PR adds VChart integration as an optional renderer for pie charts, sankey charts, and xy charts in Mermaid. Users can now choose between the default D3-based renderer and the new VChart renderer by setting the `renderer` property in their diagram configuration.

## :straight_ruler: Design Decisions

Describe the way your implementation works or what design decisions you made if applicable.

VChart as an alternative renderer rather than replacing the existing D3-based renderers, ensuring 100% backward compatibility
- **Configuration-Based Selection**: Added `renderer` property to pie, sankey, and xyChart configurations with options `'default'` and `'vchart'`
- **Composition Pattern**: Created a base `VChartRenderer` class with shared functionality and chart-specific implementations that extend it
- **Graceful Fallback**: If VChart fails to load or render, the system automatically falls back to the default renderer
### :clipboard: Tasks

Make sure you

- [ ] :book: have read the [contribution guidelines](https://mermaid.js.org/community/contributing.html)
- [ ] :computer: have added necessary unit/e2e tests.
- [ ] :notebook: have added documentation. Make sure [`MERMAID_RELEASE_VERSION`](https://mermaid.js.org/community/contributing.html#update-documentation) is used for all new features.
- [ ] :butterfly: If your PR makes a change that should be noted in one or more packages' changelogs, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, or `chore:`.
